### PR TITLE
87 The headline link for the featured article now turns blue when hovered

### DIFF
--- a/ubyssey/static/src/styles/modules/_homepage.scss
+++ b/ubyssey/static/src/styles/modules/_homepage.scss
@@ -104,6 +104,9 @@ div.frontpage {
         h1.headline {
           margin: 12px 0;
         }
+        h1.headline:hover {
+          color: $color-accent-blue;
+        }
         &.fw-story {
           text-align: center;
           h1 {
@@ -495,7 +498,7 @@ span.byline {
 
 p.snippet span.timestamp {
   font-family: $font-default;
-  color: #0071C9;
+  color: $color-accent-blue;
   font-weight: 500;
   font-size: 13px;
   margin-right: 8px;
@@ -530,12 +533,12 @@ div.multi-zone {
 			margin: 0 auto;
 			text-align: center;
 	  }
-		
+
 		img {
 			display: block;
 			margin: 0 auto;
 		}
-	  
+
   }
 }
 

--- a/ubyssey/static/src/styles/modules/_variables.scss
+++ b/ubyssey/static/src/styles/modules/_variables.scss
@@ -17,6 +17,7 @@ $bp-960px                 : "min-width: 960px" !default;
 // Colors
 
 $color-ub-blue: #3A6BCC;
+$color-accent-blue: #0071c9;
 
 // Z-Index Scale
 

--- a/ubyssey/static/src/styles/modules/article/_base.scss
+++ b/ubyssey/static/src/styles/modules/article/_base.scss
@@ -157,7 +157,7 @@ div.article-content {
   }
 
   a {
-    color: #0071c9;
+    color: $color-accent-blue;
     text-decoration: underline;
   }
 


### PR DESCRIPTION
The headline link for the featured article now turns blue when hovered, like the rest of the articles on the left hand side.

Extracted that specific color into a separate variable and refactored accordingly.

Fixes #87 
