### PR TITLE
implement carousel

### DIFF
--- a/ubyssey/static/src/js/main.js
+++ b/ubyssey/static/src/js/main.js
@@ -1,4 +1,5 @@
 import * as mp from './modules/Mixpanel';
+import upcomingEvents from './widgets/upcoming-events';
 
 function disableScroll($document) {
   $document.on('touchmove', function(e) {
@@ -134,5 +135,7 @@ function enableScroll($document) {
   } else {
     mp.pageView();
   }
+
+  upcomingEvents();
 
 })();

--- a/ubyssey/static/src/js/widgets/upcoming-events.js
+++ b/ubyssey/static/src/js/widgets/upcoming-events.js
@@ -28,7 +28,7 @@ function registerWidget() {
 
         var slideToActivate = carousel.slides[carousel.currentSlide];
         $.each(carousel.slides, function(i, slide) {
-          if (slide.css('display') != 'none') {
+          if (slide.is(':visible')) {
             slide.animate({ opacity: 0 }, FADE_OUT_SPEED, 'linear', function() {
               slide.css('display', 'none');
 

--- a/ubyssey/static/src/js/widgets/upcoming-events.js
+++ b/ubyssey/static/src/js/widgets/upcoming-events.js
@@ -28,7 +28,7 @@ function registerWidget() {
         $.each(carousel.slides, function(i, slide) {
           if (slide.css('display') != 'none') {
             slide.animate({ opacity: 0 }, 100, 'linear', function() {
-              slide.css('display', 'none')
+              slide.css('display', 'none');
 
               slideToActivate.css('opacity', 0);
               slideToActivate.css('display', 'block');
@@ -69,7 +69,7 @@ function registerWidget() {
           carousel.interval = setTimeout(startAutoplay, AUTOPLAY_SPEED / 2);
         });
 
-        buttonRow.append(button)
+        buttonRow.append(button);
         carouselButtons.push(button);
       }
 
@@ -78,4 +78,4 @@ function registerWidget() {
   });
 }
 
-module.exports = registerWidget
+module.exports = registerWidget;

--- a/ubyssey/static/src/js/widgets/upcoming-events.js
+++ b/ubyssey/static/src/js/widgets/upcoming-events.js
@@ -28,16 +28,14 @@ function registerWidget() {
         $.each(carousel.slides, function(i, slide) {
           if (slide.slideIndex == carousel.currentSlide) {
               slideToActivate = slide;
-          } else {
-            if (slide.css('display') != 'none') {
-              slide.animate({ opacity: 0 }, 100, 'linear', function() {
-                slide.css('display', 'none')
+          } else if (slide.css('display') != 'none') {
+            slide.animate({ opacity: 0 }, 100, 'linear', function() {
+              slide.css('display', 'none')
 
-                slideToActivate.css('opacity', 0);
-                slideToActivate.css('display', 'block');
-                slideToActivate.animate({ opacity: 1 }, 600, 'linear');
-              });
-            }
+              slideToActivate.css('opacity', 0);
+              slideToActivate.css('display', 'block');
+              slideToActivate.animate({ opacity: 1 }, 600, 'linear');
+            });
           }
         });
 

--- a/ubyssey/static/src/js/widgets/upcoming-events.js
+++ b/ubyssey/static/src/js/widgets/upcoming-events.js
@@ -24,11 +24,9 @@ function registerWidget() {
           carousel.currentSlide = numSlides - 1;
         }
 
-        var slideToActivate;
+        var slideToActivate = carousel.slides[carousel.currentSlide];
         $.each(carousel.slides, function(i, slide) {
-          if (slide.slideIndex == carousel.currentSlide) {
-              slideToActivate = slide;
-          } else if (slide.css('display') != 'none') {
+          if (slide.css('display') != 'none') {
             slide.animate({ opacity: 0 }, 100, 'linear', function() {
               slide.css('display', 'none')
 

--- a/ubyssey/static/src/js/widgets/upcoming-events.js
+++ b/ubyssey/static/src/js/widgets/upcoming-events.js
@@ -1,4 +1,6 @@
-var AUTOPLAY_SPEED = 5000; //ms
+var AUTOPLAY_SPEED = 5000; // ms
+var FADE_OUT_SPEED = 100; // ms
+var FADE_IN_SPEED = 600; // ms
 
 function registerWidget() {
   $('.js-carousel').each(function() {
@@ -27,12 +29,12 @@ function registerWidget() {
         var slideToActivate = carousel.slides[carousel.currentSlide];
         $.each(carousel.slides, function(i, slide) {
           if (slide.css('display') != 'none') {
-            slide.animate({ opacity: 0 }, 100, 'linear', function() {
+            slide.animate({ opacity: 0 }, FADE_OUT_SPEED, 'linear', function() {
               slide.css('display', 'none');
 
               slideToActivate.css('opacity', 0);
               slideToActivate.css('display', 'block');
-              slideToActivate.animate({ opacity: 1 }, 600, 'linear');
+              slideToActivate.animate({ opacity: 1 }, FADE_IN_SPEED, 'linear');
             });
           }
         });

--- a/ubyssey/static/src/js/widgets/upcoming-events.js
+++ b/ubyssey/static/src/js/widgets/upcoming-events.js
@@ -1,0 +1,57 @@
+function registerWidget() {
+  $('.carousel').each(function() {
+    var carousel = $(this);
+    carousel.currentSlide = 0;
+    carousel.slides = [];
+
+    carousel.find('.carousel-item').each(function(i) {
+      var item = $(this);
+      item.slideIndex = i;
+      carousel.slides.push(item);
+    });
+
+    var numSlides = carousel.slides.length;
+
+    if (numSlides > 1) {
+      carousel.moveSlide = function(n) {
+        carousel.currentSlide += n;
+
+        if (carousel.currentSlide >= numSlides) {
+          carousel.currentSlide = 0;
+        } else if (carousel.currentSlide < 0) {
+          carousel.currentSlide = numSlides - 1;
+        }
+
+        $.each(carousel.slides, function(i, slide) {
+          if (slide.slideIndex == carousel.currentSlide) {
+              slide.css('display', 'block');
+          } else {
+            slide.css('display', 'none');
+          }
+        });
+      };
+
+      // "autoplay"
+      carousel.interval = setInterval(function() {
+        carousel.moveSlide(1);
+      }, 5000);
+
+      var left = $('<div>', { 'class': 'carousel-left fa fa-arrow-circle-left' });
+      left.click(function() {
+        carousel.moveSlide(-1);
+        clearInterval(carousel.interval); // disable autoplay
+      });
+
+      var right = $('<div>', { 'class': 'carousel-right fa fa-arrow-circle-right' });
+      right.click(function() {
+        carousel.moveSlide(1);
+        clearInterval(carousel.interval);
+      });
+
+      carousel.append(left);
+      carousel.append(right);
+    }
+  });
+}
+
+module.exports = registerWidget

--- a/ubyssey/static/src/styles/modules/widgets/_upcoming_events.scss
+++ b/ubyssey/static/src/styles/modules/widgets/_upcoming_events.scss
@@ -45,32 +45,26 @@
   letter-spacing: 0.045em;
 }
 
-.carousel {
-  position: relative;
-}
+.c-widget-upcoming-events {
+  $button-color: lighten($color-text-gray-light, 10%);
 
-.carousel-left, .carousel-right {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 2;
-  padding: 10px 8px;
-  cursor: pointer;
-  box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.05);
-  border: 1px solid #e3e3e3;
+  .carousel-button-row {
+    margin: 5px 0;
+    display: flex;
+    justify-content: center;
+  }
 
-  background-color: #fff;
-  opacity: 0.65;
-}
+  .carousel-button {
+    width: 8px;
+    height: 8px;
 
-.carousel-left {
-  left: 0;
-  border-top-right-radius: 18px;
-  border-bottom-right-radius: 18px;
-}
+    cursor: pointer;
+    margin: 0 3px;
+    border: 2px solid $button-color;
+    border-radius: 18px;
+  }
 
-.carousel-right {
-  right: 0;
-  border-top-left-radius: 18px;
-  border-bottom-left-radius: 18px;
+  .carousel-button--active {
+    background-color: $button-color;
+  }
 }

--- a/ubyssey/static/src/styles/modules/widgets/_upcoming_events.scss
+++ b/ubyssey/static/src/styles/modules/widgets/_upcoming_events.scss
@@ -44,3 +44,33 @@
   font-weight: $font-weight-semi-bold;
   letter-spacing: 0.045em;
 }
+
+.carousel {
+  position: relative;
+}
+
+.carousel-left, .carousel-right {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 2;
+  padding: 10px 8px;
+  cursor: pointer;
+  box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.05);
+  border: 1px solid #e3e3e3;
+
+  background-color: #fff;
+  opacity: 0.65;
+}
+
+.carousel-left {
+  left: 0;
+  border-top-right-radius: 18px;
+  border-bottom-right-radius: 18px;
+}
+
+.carousel-right {
+  right: 0;
+  border-top-left-radius: 18px;
+  border-bottom-left-radius: 18px;
+}

--- a/ubyssey/static/src/styles/modules/widgets/_upcoming_events.scss
+++ b/ubyssey/static/src/styles/modules/widgets/_upcoming_events.scss
@@ -3,6 +3,11 @@
 
 .c-widget-upcoming-events__featured {
   margin-bottom: 0.625em;
+  display: none;
+
+  &:first-child {
+    display: block;
+  }
 }
 
 .c-widget-upcoming-events__events {

--- a/ubyssey/templates/widgets/upcoming-events.html
+++ b/ubyssey/templates/widgets/upcoming-events.html
@@ -1,7 +1,7 @@
 <div class="c-widget-upcoming-events">
-  <div class="carousel">
+  <div class="js-carousel">
     {% for featured_event in featured_events %}
-    <div class="c-widget-upcoming-events__featured carousel-item" {% ifnotequal forloop.counter0 0 %}style="display:none;"{% endifnotequal %}>
+    <div class="c-widget-upcoming-events__featured js-carousel__item" {% ifnotequal forloop.counter0 0 %}style="display:none;"{% endifnotequal %}>
       {% include '../events/event_box.html' with event=featured_event only %}
     </div>
     {% endfor %}

--- a/ubyssey/templates/widgets/upcoming-events.html
+++ b/ubyssey/templates/widgets/upcoming-events.html
@@ -1,7 +1,7 @@
 <div class="c-widget-upcoming-events">
   <div class="js-carousel">
     {% for featured_event in featured_events %}
-    <div class="c-widget-upcoming-events__featured js-carousel__item" {% ifnotequal forloop.counter0 0 %}style="display:none;"{% endifnotequal %}>
+    <div class="c-widget-upcoming-events__featured js-carousel__item">
       {% include '../events/event_box.html' with event=featured_event only %}
     </div>
     {% endfor %}

--- a/ubyssey/templates/widgets/upcoming-events.html
+++ b/ubyssey/templates/widgets/upcoming-events.html
@@ -1,9 +1,11 @@
 <div class="c-widget-upcoming-events">
-  {% if featured_event %}
-  <div class="c-widget-upcoming-events__featured">
-    {% include '../events/event_box.html' with event=featured_event only %}
+  <div class="carousel">
+    {% for featured_event in featured_events %}
+    <div class="c-widget-upcoming-events__featured carousel-item" {% ifnotequal forloop.counter0 0 %}style="display:none;"{% endifnotequal %}>
+      {% include '../events/event_box.html' with event=featured_event only %}
+    </div>
+    {% endfor %}
   </div>
-  {% endif %}
   <div class="c-widget-upcoming-events__label">Upcoming Events</div>
   <div class="c-widget-upcoming-events__events">
   {% for event in upcoming %}


### PR DESCRIPTION
- tweak the widget to take multiple featured events
- the django template applies style="display: none;" to all but the first (so that multiple aren't visible if the JS/CSS has't loaded yet)

- simple jQuery adds automatic slide change every 5 second.
- also adds buttons that stop the slideshow and allow manual movement through slides.
- registers all widgets separately, so multiple upcoming-event-widgets can be on the same page and work independently. 