### PR TITLE
Solution for failure to install MySQL-python

### DIFF
--- a/SETUP-MAC.md
+++ b/SETUP-MAC.md
@@ -43,6 +43,11 @@ _Note: you might get an error saying that `libjpeg` is required. You can install
 ```bash
 brew install libjpeg zlib
 ```
+_Note: if `mySQL-python` fails to install, you might be missing some of Apple's Command Line Tools. Install [Xcode](https://itunes.apple.com/ca/app/xcode/id497799835?mt=12) from the Mac App Store, then:_
+
+```bash
+xcode-select --install
+```
 
 ### Project settings
 


### PR DESCRIPTION
Provided solution for cases where ``MySQL-python`` doesn't install (with ``requirements.txt`` or by itself with ``pip``).