### PR TITLE
Get rid of the &:after part of .o-article-embed--code in _embeds.scss

### DIFF
--- a/ubyssey/static/src/styles/modules/article/_embeds.scss
+++ b/ubyssey/static/src/styles/modules/article/_embeds.scss
@@ -140,13 +140,6 @@
   display: inline-block;
   position: relative;
   width: 100%;
-
-  &:after {
-    // Structure
-    padding-top: 56.25%; // 16:9 ratio
-    display: inline-block;
-    content: '';
-  }
 }
 
 .o-article-embed--video {


### PR DESCRIPTION
Close #429 

The problem in #429 seems to have come about because the width for code embeds is set to 100%, and then the &:after part adds a top padding to ensure a 16:9 proportion for the embed. This basically results in a lot of extra width added to the embed, and then a lot of top padding to keep up with the extra width.