### PR TITLE
Fix 404 pages

### DIFF
--- a/_settings/settings-local.py
+++ b/_settings/settings-local.py
@@ -37,6 +37,11 @@ TEMPLATES += [
         'DIRS': [
             os.path.join(os.path.dirname(__file__), 'templates'),
         ],
+        'OPTIONS': {
+            'context_processors': [
+                'ubyssey.views.context_processors.global_settings',
+            ]
+        },
     }
 ]
 

--- a/_settings/settings-prd.py
+++ b/_settings/settings-prd.py
@@ -44,6 +44,11 @@ TEMPLATES += [
         'DIRS': [
             os.path.join(os.path.dirname(__file__), 'templates'),
         ],
+        'OPTIONS': {
+            'context_processors': [
+                'ubyssey.views.context_processors.global_settings',
+            ]
+        },
     }
 ]
 

--- a/ubyssey/views/main.py
+++ b/ubyssey/views/main.py
@@ -126,7 +126,11 @@ class UbysseyTheme(object):
         return HttpResponse(json.dumps(data), content_type='application/json')
 
     def page(self, request, slug=None):
-        page = PageHelper.get_page(request, slug)
+        try:
+            page = PageHelper.get_page(request, slug)
+        except:
+            raise Http404('Page could not be found.')
+            
         page.add_view()
 
         try:


### PR DESCRIPTION
Add context processors to settings. Forgot to add them in the streamline release process PR.

Wrap get page in try catch so that it will 404 properly if the page is not found instead of getting an exception.