### PR TITLE
Update poll styling

### DIFF
--- a/ubyssey/static/src/js/components/Poll/Poll.jsx
+++ b/ubyssey/static/src/js/components/Poll/Poll.jsx
@@ -195,6 +195,7 @@ class Poll extends Component {
     const buttonStyle = hasVoted ? 'poll-button-voted': 'poll-button-no-vote'
     const showResult = showResults ? (hasVoted ? COLOR_OPACITY : 0) : 0
     const notShowResult = showResults ? (hasVoted ? 0 : COLOR_OPACITY) : COLOR_OPACITY
+    
     return (
       <div className='poll-wrapper'>
         {!loading &&

--- a/ubyssey/static/src/js/components/Poll/PollAnswer.jsx
+++ b/ubyssey/static/src/js/components/Poll/PollAnswer.jsx
@@ -15,13 +15,16 @@ class PollAnswer extends Component {
     let buttonSelected = checkedAnswers.includes(index) ? 'poll-button-selected' : 'poll-button-not-selected'
     return(
       <label className={['poll-button-label', buttonStyle].join(' ')}>
-        <input className={'poll-input'} 
-          name={'answer'} 
-          type={'radio'} 
+        <input className={'poll-input'}
+          name={'answer'}
+          type={'radio'}
           value={answer}
           checked={this.props.checkedAnswers.includes(index)}
           onChange={(e) => this.props.changeAnswers(e, index)}>
             <span className={'poll-answer-text'}>{answer}</span>
+            <div className={isSelected}>
+              <span className={'poll-checkmark'}></span>
+            </div>
         </input>
 
         <span className={'poll-button'}
@@ -34,12 +37,9 @@ class PollAnswer extends Component {
           {answerPercentage}
         </span>
 
-        <div className={'poll-result-bar'} 
-          style={{width: answerPercentage, opacity: showResult}}>
-            <div className={isSelected}>                      
-              <span className={'poll-checkmark'}></span>
-            </div>
+        <div className={'poll-result-bar'} style={{width: answerPercentage, opacity: showResult}}>
         </div>
+        
       </label>
     )
   }

--- a/ubyssey/static/src/styles/components/_poll.scss
+++ b/ubyssey/static/src/styles/components/_poll.scss
@@ -164,14 +164,14 @@
   width: 15px;
   height: 15px;
   align-self: center;
-  position: absolute;
-  right: -30px;
+  position: relative;
+  left: 0.5rem;
   display: flex;
   align-items: center;
   justify-content: center;
 
   // Border
-  border: 2px solid $color-ub-blue-light;
+  border: 2px solid #045594;
   border-radius: 15px;
 
   // Extra
@@ -188,7 +188,8 @@
     transform: rotate(45deg);
 
     // Border
-    border: solid $color-ub-blue-light;
+    //border: 2px solid $color-ub-blue;
+    border: 2px solid #045594;
     border-width: 0 2px 2px 0;
   }
 }


### PR DESCRIPTION
I looked at other polling examples on twitter and followed their general style. I moved the checkmark to always be to the right of the answer text and darkened the colour a bit so that it is more visible when the answer bar overlaps with the checkmark