### PR TITLE
Fix event image url

### DIFF
--- a/ubyssey/events/models.py
+++ b/ubyssey/events/models.py
@@ -79,8 +79,8 @@ class Event(Model):
         Returns image URL.
         """
         if self.image:
-            return "%s%s%s/" % (settings.BASE_URL.strip("/"), settings.MEDIA_URL, str(self.image))
-
+            return settings.MEDIA_URL + str(self.image)
+            
 @receiver(pre_save, sender=Event)
 def send_submitted_email(sender, instance, **kwargs):
     """Send an email to the submitter when the event is submitted."""


### PR DESCRIPTION
fix get_absolute_url to use media url instead of base url so that it works in production