### PR TITLE
Subsection redesign

### DIFF
--- a/ubyssey/helpers.py
+++ b/ubyssey/helpers.py
@@ -6,7 +6,7 @@ from django.http import Http404
 from django.db import connection
 from django.db.models.aggregates import Count
 
-from dispatch.models import Article, Page, Section
+from dispatch.models import Article, Page, Section, Subsection
 
 from ubyssey.events.models import Event
 
@@ -306,3 +306,22 @@ class PageHelper(object):
         """
 
         return Page.objects.get(request=request, slug=slug, is_published=True)
+
+class SubsectionHelper(object):
+
+    @staticmethod
+    def get_subsections(section):
+        context = {
+            'section_id': section.id
+        }
+
+        query = """
+            SELECT * FROM dispatch_subsection
+            INNER JOIN dispatch_article on dispatch_article.subsection_id = dispatch_subsection.id
+            WHERE dispatch_subsection.is_active = 1
+            AND dispatch_subsection.section_id = %(section_id)s
+            AND dispatch_article.is_published = 1
+            ORDER BY dispatch_article.published_at DESC
+        """
+
+        return list(Subsection.objects.raw(query, context))

--- a/ubyssey/helpers.py
+++ b/ubyssey/helpers.py
@@ -326,3 +326,8 @@ class SubsectionHelper(object):
         """
 
         return list(Subsection.objects.raw(query, context))
+
+    @staticmethod
+    def get_featured_subsection_articles(subsection, featured_articles):
+        featured_articles_ids = list(featured_articles.values_list('id', flat=True)[0:4])
+        return subsection.get_published_articles().exclude(id__in=featured_articles_ids)[0:3]

--- a/ubyssey/helpers.py
+++ b/ubyssey/helpers.py
@@ -316,7 +316,8 @@ class SubsectionHelper(object):
         }
 
         query = """
-            SELECT * FROM dispatch_subsection
+            SELECT DISTINCT dispatch_subsection.id
+            FROM dispatch_subsection
             INNER JOIN dispatch_article on dispatch_article.subsection_id = dispatch_subsection.id
             WHERE dispatch_subsection.is_active = 1
             AND dispatch_subsection.section_id = %(section_id)s

--- a/ubyssey/static/src/styles/components/_section-page.scss
+++ b/ubyssey/static/src/styles/components/_section-page.scss
@@ -18,11 +18,10 @@
     list-style-type: none;
 
     li {
-      padding-left: 1rem;
       display: inline-block;
-
-      &:first-child {
-        padding-left: 0rem;
+      
+      &:not(:last-child):after {
+        content: "  |  ";
       }
     }
   }

--- a/ubyssey/static/src/styles/components/_section-page.scss
+++ b/ubyssey/static/src/styles/components/_section-page.scss
@@ -3,6 +3,31 @@
   margin-bottom: 2rem;
 }
 
+.c-page__header__subsections {
+  ul {
+    // Structure
+    margin: 0;
+    padding-left:0;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+
+    // Border
+    border-top: 1px solid #e2e2e2;;
+    border-bottom: thin groove #C8C8C8;
+
+    list-style-type: none;
+
+    li {
+      padding-left: 1rem;
+      display: inline-block;
+
+      &:first-child {
+        padding-left: 0rem;
+      }
+    }
+  }
+}
+
 .c-section__featured__articles {
 
   padding-bottom: 1rem;

--- a/ubyssey/templates/objects/subsection.html
+++ b/ubyssey/templates/objects/subsection.html
@@ -2,7 +2,9 @@
   <h3 class="c-subsection__heading"><a href="{{ subsection.get_absolute_url }}">{{ subsection.name|safe }}</a></h3>
   <div class="c-section__featured__articles u-flex--tablet">
   {% for article in subsection.get_published_articles|slice:":3" %}
-    {% include 'objects/articles/column.html' with article=article %}
+    {% ifnotequal article.id featured_article.id %}
+      {% include 'objects/articles/column.html' with article=article %}
+    {% endifnotequal %}
   {% endfor %}
   </div>
 </div>

--- a/ubyssey/templates/objects/subsection.html
+++ b/ubyssey/templates/objects/subsection.html
@@ -1,10 +1,8 @@
 <div class="c-subsection">
-  <h3 class="c-subsection__heading"><a href="{{ subsection.get_absolute_url }}">{{ subsection.name|safe }}</a></h3>
+  <h3 class="c-subsection__heading"><a href="{{ featured_subsection.subsection.get_absolute_url }}">{{ featured_subsection.subsection.name|safe }}</a></h3>
   <div class="c-section__featured__articles u-flex--tablet">
-  {% for article in subsection.get_published_articles|slice:":3" %}
-    {% ifnotequal article.id featured_article.id %}
-      {% include 'objects/articles/column.html' with article=article %}
-    {% endifnotequal %}
+  {% for article in featured_subsection.articles %}
+    {% include 'objects/articles/column.html' with article=article %}
   {% endfor %}
   </div>
 </div>

--- a/ubyssey/templates/section.html
+++ b/ubyssey/templates/section.html
@@ -12,7 +12,15 @@
     <div class="c-page__header">
       <h1 class="c-page__heading">{{ section.name }}</h1>
     </div>
-
+    {% if subsections %}
+      <div class="c-page__header__subsections">
+        <ul>
+          {% for subsection in subsections %}
+            <li><a href="{% url 'page' subsection.slug %}">{{ subsection.name }}</a></li>
+          {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
     <div class="c-section__featured">
       {% include 'objects/articles/featured.html' with article=featured_articles.first %}
       <div class="c-section__featured__articles u-flex--tablet">

--- a/ubyssey/templates/section.html
+++ b/ubyssey/templates/section.html
@@ -28,11 +28,9 @@
         {% include 'objects/articles/column.html' with article=article %}
       {% endfor %}
       </div>
-      {% for subsection in subsections %}
-        {% if subsection.get_published_articles %}
-          {% include 'objects/subsection.html' with subsection=subsection %}
+        {% if featured_subsection %}
+          {% include 'objects/subsection.html' with subsection=featured_subsection %}
         {% endif %}
-      {% endfor %}
     </div>
 
     <h3 class="c-page__section">Archive</h3>

--- a/ubyssey/templates/section.html
+++ b/ubyssey/templates/section.html
@@ -28,8 +28,8 @@
         {% include 'objects/articles/column.html' with article=article %}
       {% endfor %}
       </div>
-        {% if featured_subsection %}
-          {% include 'objects/subsection.html' with subsection=featured_subsection featured_article=featured_articles.first %}
+        {% if featured_subsection.subsection %}
+          {% include 'objects/subsection.html' with featured_subsection=featured_subsection %}
         {% endif %}
     </div>
 

--- a/ubyssey/templates/section.html
+++ b/ubyssey/templates/section.html
@@ -29,7 +29,7 @@
       {% endfor %}
       </div>
         {% if featured_subsection %}
-          {% include 'objects/subsection.html' with subsection=featured_subsection %}
+          {% include 'objects/subsection.html' with subsection=featured_subsection featured_article=featured_articles.first %}
         {% endif %}
     </div>
 

--- a/ubyssey/views/main.py
+++ b/ubyssey/views/main.py
@@ -241,15 +241,15 @@ class UbysseyTheme(object):
 
         query = request.GET.get('q', False)
 
+        featured_articles = Article.objects.filter(section=section, is_published=True).order_by('-published_at')
+
         subsections = SubsectionHelper.get_subsections(section)
 
         featured_subsection = None
 
         if subsections:
             featured_subsection = subsections[0]
-
-        featured_article = Article.objects.filter(section=section, is_published=True).order_by('-published_at').first()
-        featured_articles = Article.objects.filter(section=section, is_published=True).exclude(subsection__in=subsections).order_by('-published_at')
+            featured_subsection_articles = SubsectionHelper.get_featured_subsection_articles(featured_subsection, featured_articles)
 
         article_list = Article.objects.filter(section=section, is_published=True).order_by(order_by)
 
@@ -275,10 +275,13 @@ class UbysseyTheme(object):
             },
             'section': section,
             'subsections': subsections,
-            'featured_subsection': featured_subsection,
+            'featured_subsection': {
+                'subsection': featured_subsection,
+                'articles' : featured_subsection_articles
+            },
             'type': 'section',
             'featured_articles': {
-                'first': featured_article,
+                'first': featured_articles[0],
                 'rest': featured_articles[1:4]
             },
             'articles': articles,

--- a/ubyssey/views/main.py
+++ b/ubyssey/views/main.py
@@ -248,7 +248,8 @@ class UbysseyTheme(object):
         if subsections:
             featured_subsection = subsections[0]
 
-        featured_articles = Article.objects.filter(section=section, is_published=True).order_by('-published_at')
+        featured_article = Article.objects.filter(section=section, is_published=True).order_by('-published_at').first()
+        featured_articles = Article.objects.filter(section=section, is_published=True).exclude(subsection__in=subsections).order_by('-published_at')
 
         article_list = Article.objects.filter(section=section, is_published=True).order_by(order_by)
 
@@ -277,7 +278,7 @@ class UbysseyTheme(object):
             'featured_subsection': featured_subsection,
             'type': 'section',
             'featured_articles': {
-                'first': featured_articles[0],
+                'first': featured_article,
                 'rest': featured_articles[1:4]
             },
             'articles': articles,

--- a/ubyssey/views/main.py
+++ b/ubyssey/views/main.py
@@ -242,6 +242,14 @@ class UbysseyTheme(object):
         query = request.GET.get('q', False)
 
         subsections = Subsection.objects.filter(section=section, is_active=True)
+        featured_subsections = []
+        for subsection in subsections:
+            most_recent_publish_date = subsection.get_published_articles().first().published_at
+            featured_subsections.append((subsection, most_recent_publish_date))
+        print('suup',featured_subsections)
+
+        featured_subsections = sorted(featured_subsections, key=lambda tup: tup[1])
+        print('suup',featured_subsections)
 
         featured_articles = Article.objects.filter(section=section, is_published=True).exclude(subsection__in=subsections).order_by('-published_at')
 

--- a/ubyssey/views/main.py
+++ b/ubyssey/views/main.py
@@ -241,7 +241,7 @@ class UbysseyTheme(object):
 
         query = request.GET.get('q', False)
 
-        subsections = SubsectionHelper.get_subsections(section)#Subsection.objects.filter(section=section, is_active=True)
+        subsections = SubsectionHelper.get_subsections(section)
 
         featured_subsection = None
 

--- a/ubyssey/views/main.py
+++ b/ubyssey/views/main.py
@@ -16,7 +16,7 @@ from dispatch.models import Article, Section, Subsection, Topic, Person
 
 import ubyssey
 import ubyssey.cron
-from ubyssey.helpers import ArticleHelper, PageHelper
+from ubyssey.helpers import ArticleHelper, PageHelper, SubsectionHelper
 
 def parse_int_or_none(maybe_int):
     try:
@@ -241,15 +241,12 @@ class UbysseyTheme(object):
 
         query = request.GET.get('q', False)
 
-        subsections = Subsection.objects.filter(section=section, is_active=True)
-        featured_subsections = []
-        for subsection in subsections:
-            most_recent_publish_date = subsection.get_published_articles().first().published_at
-            featured_subsections.append((subsection, most_recent_publish_date))
-        print('suup',featured_subsections)
+        subsections = SubsectionHelper.get_subsections(section)#Subsection.objects.filter(section=section, is_active=True)
 
-        featured_subsections = sorted(featured_subsections, key=lambda tup: tup[1])
-        print('suup',featured_subsections)
+        featured_subsection = None
+
+        if subsections:
+            featured_subsection = subsections[0]
 
         featured_articles = Article.objects.filter(section=section, is_published=True).exclude(subsection__in=subsections).order_by('-published_at')
 
@@ -277,6 +274,7 @@ class UbysseyTheme(object):
             },
             'section': section,
             'subsections': subsections,
+            'featured_subsection': featured_subsection,
             'type': 'section',
             'featured_articles': {
                 'first': featured_articles[0],

--- a/ubyssey/views/main.py
+++ b/ubyssey/views/main.py
@@ -248,7 +248,7 @@ class UbysseyTheme(object):
         if subsections:
             featured_subsection = subsections[0]
 
-        featured_articles = Article.objects.filter(section=section, is_published=True).exclude(subsection__in=subsections).order_by('-published_at')
+        featured_articles = Article.objects.filter(section=section, is_published=True).order_by('-published_at')
 
         article_list = Article.objects.filter(section=section, is_published=True).order_by(order_by)
 


### PR DESCRIPTION
Redesign/rework for subsections. Including some styling changes and changes for how the articles to be shown for each subsection are selected.

1. Added a small header that lists all of the active subsections that have published articles
![header_subsections](https://user-images.githubusercontent.com/5742577/45322969-a653c200-b4fe-11e8-8a9d-8dff9f6a18ee.jpeg)

2. Only show 1 subsection on the section page. This subsection is chosen by taking the subsection (associated with this section) that has the most recently published article. 

3. So as to still promote new articles when they are published, the featured articles section is reverted to its original functionality, however the articles shown in the featured subsection are now chosen as to not show any duplicate articles that are already on the page.
![duplicates](https://user-images.githubusercontent.com/5742577/45323095-02b6e180-b4ff-11e8-8f9d-bd84ccf6520a.jpeg)
