### PR TITLE
Allow pdb to be attach on docker

### DIFF
--- a/local-dev/docker-compose.yml
+++ b/local-dev/docker-compose.yml
@@ -51,6 +51,9 @@ services:
       db:
         condition: service_healthy
     container_name: ubyssey-dev
+    stdin_open: true
+    tty: true
+
 
 volumes:
   data: {}


### PR DESCRIPTION
Based on [stackoverflow answer like this ](https://stackoverflow.com/questions/32403664/make-pdb-work-with-docker), we need to add two lines to allow docker to let terminal attach to ongoing `pdb` session. I've had it on my local file, but it should be updated on repo level to allow everyone to debug easily (added in our [faq](http://code.ubyssey.ca/faq) page)