### PR TITLE
Add .editorconifg

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# http://editorconfig.org
+
+[*]
+# Set default charset
+charset = utf-8
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true
+# Unix-style newlines with a newline ending every file
+end_of_line = lf
+insert_final_newline = true
+
+# 4 space indentation for py
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ __pycache__/
 /ubyssey/static/dist/
 
 # local GAE
-/lib/   
+/lib/
 
 node_modules/
 yarn.lock
@@ -17,8 +17,9 @@ yarn.lock
 # Ignore Mac specific empty file
 .DS_Store
 
-# Ignore settings for vscode
+# Ignore settings for vscode except extensions.json
 .vscode
+!.vscode/extensions.json
 
 ubyssey/settings*.py
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "chrisdias.vscodeEditorConfig"
+  ]
+}
+


### PR DESCRIPTION
## Problem
Everyone uses different editors, and code format differs depending on which editor configuration a developer use

## Solution
[Editorconfig](https://editorconfig.org/) allows the style to be consistent across different editors. `.editorconfig` file is a config file to use it. It should apply the configured setting as you save files.

One caveat is that it required an editor to download editorconfig extension. this PR also adds `.vscode/extensions.json` that allows vscode users (ex. most new volunteers) to be suggested to download included extension

Ex:
![image](https://user-images.githubusercontent.com/9669739/50131910-45dccb00-0239-11e9-987d-999b77810c2b.png)

