### PR TITLE
Add github issue & pr template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+    This template is for an issue. 
+    If the issue is for feature request, please start clean and tell us why and what feature you want
+-->
+
+## What behavior were you expecting?
+
+<!--
+    Add screenshot if appropriate
+-->
+
+## What actually happened?
+
+## Steps to reproduce
+
+## What was your environment like?
+
+<!--
+    Browser version, mobile OS, etc
+-->
+
+## Do you have any logs?
+
+<!--
+    Either screenshot or copy & paste wrapped in `` to enable code formatting
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## What problem does this PR solve?
+
+<!--
+    Reference the issue # if appropriate
+-->
+
+## How did you fix the problem?
+
+<!--
+    Include a summary of the change.
+-->


### PR DESCRIPTION
[GitHub blog on templates](https://blog.github.com/2016-02-17-issue-and-pull-request-templates/)

![image](https://user-images.githubusercontent.com/9669739/50133014-a8849580-023e-11e9-89f1-b610d14ee2d7.png)

## Problem

We're missing a template for GitHub issues & pr

## Solution

Add template for issues & pr. These templates will be there when someone tries to open new ticket :muscle: 

Feel free to comment if something could sound better