### PR TITLE
remove missing edge case from get_reading_list

### DIFF
--- a/ubyssey/helpers.py
+++ b/ubyssey/helpers.py
@@ -158,14 +158,12 @@ class ArticleHelper(object):
 
     @staticmethod
     def get_reading_list(article, ref=None, dur=None):
-        articles = None
-        if ref is not None:
-            if ref == 'frontpage':
-                articles = ArticleHelper.get_frontpage(exclude=[article.parent_id])
-                name = 'Top Stories'
-            elif ref == 'popular':
-                articles = ArticleHelper.get_popular(dur=dur).exclude(pk=article.id)[:5]
-                name = "Most popular this week"
+        if ref == 'frontpage':
+            articles = ArticleHelper.get_frontpage(exclude=[article.parent_id])
+            name = 'Top Stories'
+        elif ref == 'popular':
+            articles = ArticleHelper.get_popular(dur=dur).exclude(pk=article.id)[:5]
+            name = "Most popular this week"
         else:
             articles = article.get_related()
             name = article.section.name


### PR DESCRIPTION
## What problem does this PR solve?
500 error when `get_reading_list` is called with a ref that is not `popular` or `frontpage`
<!--
    Reference the issue # if appropriate
-->

## How did you fix the problem
Fixed the missing edge case in `get_reading_list`. Before when the ref was `not None`, get_reading_list did not assign `articles` a value if the ref was not `popular` or `frontpage`.
