### PR TITLE
Add django-debug-toolbar to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyyaml
 ua-parser
 user-agents
 django-user-agents
+django-debug-toolbar


### PR DESCRIPTION
We forgot to add it to the requirements.txt so new volunteers need to manually install it themselves rn