### PR TITLE
remove z-index, position poll-result as first child of label

### DIFF
--- a/ubyssey/static/src/js/components/Poll/PollAnswer.jsx
+++ b/ubyssey/static/src/js/components/Poll/PollAnswer.jsx
@@ -15,6 +15,9 @@ class PollAnswer extends React.Component {
     let buttonSelected = checkedAnswers.includes(index) ? 'poll-button-selected' : 'poll-button-not-selected'
     return(
       <label className={['poll-button-label', buttonStyle].join(' ')}>
+        <div className={'poll-result-bar'} style={{width: answerPercentage, opacity: showResult}}>
+        </div>
+        
         <input className={'poll-input'}
           name={'answer'}
           type={'radio'}
@@ -37,9 +40,6 @@ class PollAnswer extends React.Component {
           {answerPercentage}
         </span>
 
-        <div className={'poll-result-bar'} style={{width: answerPercentage, opacity: showResult}}>
-        </div>
-        
       </label>
     )
   }

--- a/ubyssey/static/src/styles/components/_poll.scss
+++ b/ubyssey/static/src/styles/components/_poll.scss
@@ -75,8 +75,8 @@
   position: absolute;
   display: flex;
   left: 0;
+  top: 0;
   height: 100%;
-  z-index: -1;
   width: 0;
 
   // Extra
@@ -188,7 +188,6 @@
     transform: rotate(45deg);
 
     // Border
-    //border: 2px solid $color-ub-blue;
     border: 2px solid #045594;
     border-width: 0 2px 2px 0;
   }
@@ -197,6 +196,9 @@
 .poll-answer-text {
   // Structure
   margin-left: 3rem;
+
+  // Extra
+  z-indeX: 1;
 }
 
 .poll-edit-button {


### PR DESCRIPTION
## What problem does this PR solve?
Fixes the poll results to their parent label elements while scrolling. #633 

## How did you fix the problem?
`z-index: -1` caused unexpected behavior on the absolute position div `poll-result-bar`. Removed `z-index` and placed the `poll-result-bar` div as first child of the `poll-button-label`.