### PR TITLE
Added message incase no events in the week

### DIFF
--- a/ubyssey/templates/events/events.html
+++ b/ubyssey/templates/events/events.html
@@ -71,6 +71,8 @@
           {% include 'components/event-box.html' with event=event %}
           </div>
         </div>
+      {% empty %}
+        There is no scheduled event for this week.
       {% endfor %}
       </div>
     </div>


### PR DESCRIPTION
## What problem does this PR solve?
There was no message shown in case there were no events in a week. Now it shows a message.
<!--
    Reference the issue # if appropriate
-->
Issue no. #647

## How did you fix the problem?
In the events.html I added a empty tag to display message in case the events list was empty.
<!--
    Include a summary of the change.
-->
I added two lines in events.html to  dispay message "There is no scheduled event for this week." 