### PR TITLE
Add images, videos, podcasts, podcast episodes on the archive

### DIFF
--- a/ubyssey/helpers.py
+++ b/ubyssey/helpers.py
@@ -362,7 +362,7 @@ class VideoHelper(object):
         return "%svideos/" % (settings.BASE_URL)
 
     @staticmethod
-    def get_video_author_url(person_slug):
+    def get_media_author_url(person_slug):
         """ Return the archive url for the video author"""
         return "%sauthors/%s/" % (settings.BASE_URL, person_slug)
 

--- a/ubyssey/templates/objects/archive.html
+++ b/ubyssey/templates/objects/archive.html
@@ -170,23 +170,66 @@
       {% if articles|length > 0 %}
       <div class="o-archive__main__list">
       {% for object in articles %}
-        {% if object == "articles" %}
+        {% if forloop.counter0 == articles_start_idx and articles.number == articles_start_page %}
           <div class="o-archive__divider">
             <div class="o-archive__line"></div>
             <div class="o-archive__line_text">Articles</div>
             <div class="o-archive__line"></div>
           </div>
-          
-        {% elif object == "people" %}
-        <div class="o-archive__divider">
+        {% endif %}
+       
+        {% if forloop.counter0 == people_start_idx and articles.number == people_start_page %}
+          <div class="o-archive__divider">
             <div class="o-archive__line"></div>
             <div class="o-archive__line_text">People</div>
             <div class="o-archive__line"></div>
           </div>
-        {% elif object.headline %}
+        {% endif %}
+
+        {% if forloop.counter0 == videos_start_idx and articles.number == videos_start_page %}
+          <div class="o-archive__divider">
+            <div class="o-archive__line"></div>
+            <div class="o-archive__line_text">Videos</div>
+            <div class="o-archive__line"></div>
+          </div>
+        {% endif %}
+
+        {% if forloop.counter0 == images_start_idx and articles.number == images_start_page %}
+          <div class="o-archive__divider">
+            <div class="o-archive__line"></div>
+            <div class="o-archive__line_text">Images</div>
+            <div class="o-archive__line"></div>
+          </div>
+        {% endif %}
+
+        {% if forloop.counter0 == podcasts_start_idx and articles.number == podcasts_start_page %}
+          <div class="o-archive__divider">
+            <div class="o-archive__line"></div>
+            <div class="o-archive__line_text">Podcasts</div>
+            <div class="o-archive__line"></div>
+          </div>
+        {% endif %}
+
+        {% if forloop.counter0 == episodes_start_idx and articles.number == episodes_start_page %}
+          <div class="o-archive__divider">
+            <div class="o-archive__line"></div>
+            <div class="o-archive__line_text">Podcast Episodes</div>
+            <div class="o-archive__line"></div>
+          </div>
+        {% endif %}
+
+        {% if object.headline %}
           {% include 'objects/articles/list.html' with article=object %}
-        {% else %}
+        {% elif object.full_name %}
           {% include 'objects/author_list.html' with person=object %}
+        {% elif object.img %}
+          {% include 'objects/image_list.html' with image=object %}
+        {% elif object.0 and object.0.podcast_id %}
+          {% include 'objects/podcasts/episode_list.html' with episode=object %}
+        {% elif object.0 and object.0.owner_email %}
+          {% include 'objects/podcasts/podcast_list.html' with podcast=object %}
+        {% else %}
+          {% include 'objects/videos/list.html' with video=object %}
         {% endif %}
       {% endfor %}
       </div>
@@ -206,7 +249,7 @@
       </div>
 
       {% else %}
-      <div class="o-archive__no-results">No articles found 😔</div>
+      <div class="o-archive__no-results">No content found 😔</div>
       {% endif %}
 
     </div>

--- a/ubyssey/templates/objects/articles/list.html
+++ b/ubyssey/templates/objects/articles/list.html
@@ -7,7 +7,7 @@
           {% if article.featured_image %}
             <img src="{{ article.featured_image.image.get_thumbnail_url }}" />
           {% else %}
-            <img src="http://img.youtube.com/vi/{{ article.featured_video.video.url|youtube_embed_id|safe }}/0.jpg" />
+            <img src="https://img.youtube.com/vi/{{ article.featured_video.video.url|youtube_embed_id|safe }}/0.jpg" />
           {% endif %}
         </a>
       </div>

--- a/ubyssey/templates/objects/image_list.html
+++ b/ubyssey/templates/objects/image_list.html
@@ -1,0 +1,27 @@
+<article class="o-article o-article--list">
+    <a style="margin-right: 0.65rem;" href="{{ image.get_absolute_url }}">
+        <img class="article-attachment" data-id="{{ image.id }}" src="{{ image.get_thumbnail_url }}" alt="{{ image.title }}" />
+    </a>
+    
+    <div class="o-article__right">
+        <div class="o-article__meta">
+            <h3 style="margin: 0px;">
+                <a href="{{ image.get_absolute_url }}">{{ image.title|default_if_none:"Untitled" }}</a>
+            </h3>
+            {% if not hide_byline %}
+                <div class="o-article__byline">
+                    {% if image.imageAuthors %}
+                        <span class="o-article__author">By
+                            {% for author in image.imageAuthors %}
+                                {% if forloop.last and image.numAuthors > 1 %} and {% endif %}
+                                <a href="{{ author.link }}">{{ author.name|safe }}</a>{% if not forloop.last and forloop.counter != image.numAuthors|add:-1 %},{% endif %}
+                            {% endfor %}
+                        </span>
+                        <span> &nbsp;·&nbsp; </span>
+                    {% endif %}
+                    <span class="o-article__published">{{ image.created_at }}</span>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+</article>

--- a/ubyssey/templates/objects/podcasts/episode_list.html
+++ b/ubyssey/templates/objects/podcasts/episode_list.html
@@ -1,0 +1,20 @@
+<article class="o-article o-article--list">
+        <a style="margin-right: 0.65rem;" href="{{ episode.1 }}">
+            <img class="article-attachment" data-id="{{ episode.0.image_id }}" src="{{ episode.0.image.get_thumbnail_url }}" alt="{{ episode.0.title }}" />
+        </a>
+        
+        <div class="o-article__right">
+            <div class="o-article__meta">
+                <h3 style="margin: 0px;">
+                    <a href="{{ episode.1 }}">{{ episode.0.title|safe }}</a>
+                </h3>
+                {% if not hide_byline %}
+                    <div class="o-article__byline">
+                        <span class="o-article__author">By {{ episode.0.author|safe }}</span>
+                        <span> &nbsp;·&nbsp; </span>
+                        <span class="o-article__published">{{ episode.0.published_at }}</span>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    </article>

--- a/ubyssey/templates/objects/podcasts/podcast_list.html
+++ b/ubyssey/templates/objects/podcasts/podcast_list.html
@@ -1,0 +1,18 @@
+<article class="o-article o-article--list">
+        <a style="margin-right: 0.65rem;" href="{{ podcast.1 }}">
+            <img class="article-attachment" data-id="{{ podcast.0.image_id }}" data-credit="{{ podcast.0.author }}" src="{{ podcast.0.image.get_thumbnail_url }}" alt="{{ podcast.0.title }}" />
+        </a>
+        
+        <div class="o-article__right">
+            <div class="o-article__meta">
+                <h3 style="margin: 0px;">
+                    <a href="{{ podcast.1 }}">{{ podcast.0.title|safe }}</a>
+                </h3>
+                {% if not hide_byline %}
+                    <div class="o-article__byline">
+                        <span class="o-article__author">By {{ podcast.0.author|safe }}</span>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    </article>

--- a/ubyssey/templates/objects/videos/list.html
+++ b/ubyssey/templates/objects/videos/list.html
@@ -1,0 +1,32 @@
+<article style="margin-top: 1.5rem; margin-bottom: 1.5rem; padding-bottom: 1.5rem; border-bottom: thin dotted #C8C8C8;" class="o-article o-article--column">
+  <div class="o-article__meta">
+    <div class="o-article__meta__image">
+      {% if video.youtube_slug %}
+        <a class="o-article__image" href="{{ video.video_url }}" style="background-image: url('https://img.youtube.com/vi/{{ video.youtube_slug }}/0.jpg');"></a>
+      {% endif %}
+        
+      <div class="o-article__right">
+        <div class="o-article__meta">
+          <h3 style="margin: 0px;">
+            <a href="{{ video.video_url }}">{{ video.title|safe }}</a>
+          </h3>
+          {% if not hide_byline %}
+            <div class="o-article__byline">
+              {% if video.videoAuthors %}
+                <span class="o-article__author">By
+                  {% for author in video.videoAuthors %}
+                    {% if forloop.last and video.numAuthors > 1 %} and {% endif %}
+                      <a href="{{ author.link }}">{{ author.name|safe }}</a>{% if not forloop.last and forloop.counter != video.numAuthors|add:-1 %},{% endif %}
+                    {% endfor %}
+                </span>
+                <span> &nbsp;·&nbsp; </span>
+              {% endif %}
+              <span class="o-article__published">{{ video.created_at }}</span>
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+</article>
+  


### PR DESCRIPTION
## What problem does this PR solve?

It solves the issue of not having images, videos, podcasts, podcast episodes on the archive. Also, it displays images, articles, podcasts, podcast episodes for each editor, in the archive. This PR fixes the issue (#663 ) of having a wrong count of objects displayed on the archive. 

## How did you fix the problem?

I added a list.html template for each media object that is displayed on the archive. To solve the issue with the wrong count of objects displayed in the archive, I computed the start index and page of each set of media objects (ie: the start index and page of images, the start index and page of articles, etc.). 