### PR TITLE
Magazine 2020 fixes

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,6 @@
 runtime: python37
 entrypoint: gunicorn -b :$PORT --chdir ubyssey/ wsgi:application
-instance_class: F2
+instance_class: F4
 
 automatic_scaling:
   max_idle_instances: 2

--- a/ubyssey/static/src/js/components/Magazine/2019/ArticleBox.jsx
+++ b/ubyssey/static/src/js/components/Magazine/2019/ArticleBox.jsx
@@ -1,7 +1,7 @@
 import React from "react"
 
 function ArticleBox(props) {
-  const background = props.image ? { "background-image": `url(${props.image})` } : null
+  const background = props.image ? { backgroundImage: `url(${props.image})` } : null
   const transition = { transitionDelay: `${props.index * 0.125}s` }
   const boxStyle = Object.assign({}, background, transition)
   return (

--- a/ubyssey/static/src/js/magazine.js
+++ b/ubyssey/static/src/js/magazine.js
@@ -7,9 +7,9 @@ $(function() {
     <Magazine
       articles={$("#magazine-wrapper").data("articles")}
       cover={$("#magazine-wrapper").data("cover")}
-      waysForwardImage={$("#magazine-wrapper").data("waysForwardImage")}
-      comesAroundImage={$("#magazine-wrapper").data("comesAroundImage")}
-      goesAroundImage={$("#magazine-wrapper").data("goesAroundImage")}
+      waysForwardImage={$("#magazine-wrapper").data("waysforward-image")}
+      comesAroundImage={$("#magazine-wrapper").data("comesaround-image")}
+      goesAroundImage={$("#magazine-wrapper").data("goesaround-image")}
       title={$("#magazine-wrapper").data("title")}
     />,
     $("#magazine-wrapper")[0]

--- a/ubyssey/templates/article/magazine-poem.html
+++ b/ubyssey/templates/article/magazine-poem.html
@@ -38,7 +38,7 @@
       </div>
 
       <div class="c-article__explore u-container u-container--small">
-        <a href="{% url 'magazine-landing' %}">Explore the magazine</a>
+        <a href="{% url 'magazine-landing' year %}">Explore the magazine</a>
       </div>
 
       {% include 'magazine/footer-poetry.html' %}

--- a/ubyssey/templates/article/magazine.html
+++ b/ubyssey/templates/article/magazine.html
@@ -41,7 +41,7 @@
     </div>
 
     <div class="c-article__explore u-container u-container--small">
-      <a href="{% url 'magazine-landing' %}">Explore the magazine</a>
+      <a href="{% url 'magazine-landing' year %}">Explore the magazine</a>
     </div>
 
   </article>

--- a/ubyssey/templates/headers/topbar.html
+++ b/ubyssey/templates/headers/topbar.html
@@ -28,6 +28,9 @@
                 <li {% if section == 'videos' %}class="current"{% endif %}>
                     <a href="{% url 'page' 'videos' %}">Video</a>
                 </li>
+                <li {% if section == 'magazine' %}class="current"{% endif %}>
+                    <a href="{% url 'magazine-landing' 2020 %}">Magazine</a>
+                </li>
                 <!--<li {% if section in 'events,podcast,magazine,whobyssey' %}class="current"{% endif %} id="sections-more-dropdown">
                     <a href="#">More</a>
                     <ul class="sections-more">

--- a/ubyssey/templates/magazine/2019/landing.html
+++ b/ubyssey/templates/magazine/2019/landing.html
@@ -1,6 +1,6 @@
 {% extends 'magazine/base.html' %}
 {% load static %}
-{% load dispatch_tags%}
+{% load dispatch_tags %}
 {% block content %}
 
 <link

--- a/ubyssey/templates/magazine/2020/landing.html
+++ b/ubyssey/templates/magazine/2020/landing.html
@@ -1,6 +1,6 @@
 {% extends 'magazine/base.html' %}
 {% load static %}
-{% load dispatch_tags%}
+{% load dispatch_tags %}
 {% block content %}
 
 <link

--- a/ubyssey/templates/magazine/footer-poetry.html
+++ b/ubyssey/templates/magazine/footer-poetry.html
@@ -1,5 +1,5 @@
 <footer class="c-footer c-footer--poetry u-container u-container--extra-large">
-  <div class="c-footer__left"><a class="o-link" href="{% url 'magazine-landing' %}">The Ubyssey Magazine</a></div>
+  <div class="c-footer__left"><a class="o-link" href="{% url 'magazine-landing' year %}">The Ubyssey Magazine</a></div>
   <div class="c-footer__center">&copy; {% now "Y" %} The Ubyssey</div>
   <div class="c-footer__right"><a class="o-link" href="{% url 'home' %}">Back to ubyssey.ca</a></div>
 </footer>

--- a/ubyssey/templates/magazine/header-poetry.html
+++ b/ubyssey/templates/magazine/header-poetry.html
@@ -1,4 +1,4 @@
 <header class="c-header c-header--poetry u-container u-container--extra-large">
-  <a class="c-header__logo" style="color: {{ color_a }}; border-color: {{ color_b }};" href="{% url 'magazine-landing' %}">The Ubyssey Magazine</a>
-  <div class="c-header__right"><a class="o-link" href="{% url 'magazine-landing' %}">{{title}}</a> &nbsp;&middot;&nbsp; <a class="o-link" href="{% url 'home' %}">The Ubyssey</a></div>
+  <a class="c-header__logo" style="color: {{ color_a }}; border-color: {{ color_b }};" href="{% url 'magazine-landing' year %}">The Ubyssey Magazine</a>
+  <div class="c-header__right"><a class="o-link" href="{% url 'magazine-landing' year %}">{{title}}</a> &nbsp;&middot;&nbsp; <a class="o-link" href="{% url 'home' %}">The Ubyssey</a></div>
 </header>

--- a/ubyssey/templates/magazine/header.html
+++ b/ubyssey/templates/magazine/header.html
@@ -1,4 +1,4 @@
 <header class="c-header c-header--{{ color }} c-header--{{subsection}} u-container u-container--extra-large">
   <a class="c-header__logo" href="{% url 'magazine-landing' year %}">The Ubyssey Magazine</a>
-  <div class="c-header__right"><a class="o-link" href="{% url 'magazine-landing' %}">{{title}}</a> &nbsp;&middot;&nbsp; <a class="o-link" href="{% url 'home' %}">The Ubyssey</a></div>
+  <div class="c-header__right"><a class="o-link" href="{% url 'magazine-landing' year %}">{{title}}</a> &nbsp;&middot;&nbsp; <a class="o-link" href="{% url 'home' %}">The Ubyssey</a></div>
 </header>

--- a/ubyssey/urls.py
+++ b/ubyssey/urls.py
@@ -53,10 +53,8 @@ urlpatterns += [
     re_path(r'^guide/(?P<slug>[-\w]+)/$', guide.article, name='guide-article'),
 
     # Magazine
-    # re_path(r'^magazine/$', magazine.landing, name='magazine-landing'),
-    # re_path(r'^magazine/2017/$', magazine.landing_2017, name='magazine-landing-2017'),
-    # re_path(r'^magazine/2018/$', magazine.landing_2018, name='magazine-landing-2018'),
     re_path(r'^magazine/(?P<year>[0-9]{4})/$', magazine_theme.magazine, name='magazine-landing'),
+    re_path(r'^magazine/(?P<slug>[-\w]+)/$', magazine_theme.article, name='magazine-article'),
 
     # Advertising
     re_path(r'^advertise/$', advertise.new, name='advertise-new'),

--- a/ubyssey/views/magazine.py
+++ b/ubyssey/views/magazine.py
@@ -210,7 +210,7 @@ mag2020 = MagazineV2(
     'magazine/2020/landing.html',
     'images/magazine/2020/section1.png',
     'images/magazine/2020/section2.png',
-    'images/magazine/2020/section3.png',
+    'images/magazine/2020/section3.jpg',
     'goesAround',
     'comesAround',
     'waysForward',

--- a/ubyssey/views/magazine.py
+++ b/ubyssey/views/magazine.py
@@ -74,7 +74,7 @@ class Magazine(object):
             'meta': ArticleHelper.get_meta(article, default_image=static('images/magazine/cover-social.png')),
             'article': article,
             'subsection': subsection,
-            'specific_css': 'css/magazine-' + year + '.css',
+            'specific_css': 'css/magazine-' + self.year + '.css',
             'year': self.year,
             'suggested': ArticleHelper.get_random_articles(2, 'magazine', exclude=article.id),
             'base_template': 'magazine/base.html',

--- a/ubyssey/views/magazine.py
+++ b/ubyssey/views/magazine.py
@@ -149,12 +149,14 @@ class MagazineV2(Magazine):
                     'featured_image': featuredImage,
                     'color': color
             }
-            if article.subsection.slug == section1_name:
-                section1.append(temp.copy())
-            elif article.subsection.slug == section2_name:
-                section2.append(temp.copy())
-            elif article.subsection.slug == section3_name:
-                section3.append(temp.copy())
+
+            if article.subsection:
+                if article.subsection.slug == self.section1_name:
+                    section1.append(temp.copy())
+                elif article.subsection.slug == self.section2_name:
+                    section2.append(temp.copy())
+                elif article.subsection.slug == self.section3_name:
+                    section3.append(temp.copy())
 
         articles = json.dumps({
                 self.section1_name: section1,

--- a/ubyssey/views/magazine.py
+++ b/ubyssey/views/magazine.py
@@ -75,6 +75,7 @@ class Magazine(object):
             'article': article,
             'subsection': subsection,
             'specific_css': 'css/magazine-' + year + '.css',
+            'year': self.year,
             'suggested': ArticleHelper.get_random_articles(2, 'magazine', exclude=article.id),
             'base_template': 'magazine/base.html',
             'magazine_title': self.title,

--- a/ubyssey/views/magazine.py
+++ b/ubyssey/views/magazine.py
@@ -143,11 +143,12 @@ class MagazineV2(Magazine):
         for article in articles:
             featuredImage = article.featured_image.image.get_medium_url() if article.featured_image is not None else None
             color = article.template_fields['color'] if 'color' in article.template_fields else None
+            
             temp = {
-                    'headline': article.headline,
-                    'url': article.get_absolute_url(),
-                    'featured_image': featuredImage,
-                    'color': color
+                'headline': article.headline,
+                'url': article.get_absolute_url(),
+                'featured_image': featuredImage,
+                'color': color
             }
 
             if article.subsection:


### PR DESCRIPTION
## What problem does this PR solve?

Solves various bugs in the 2020 Magazine template.

## How did you fix the problem?

- Add missing URL route for magazine article
- Add missing year argument to magazine-landing URL reverse
- Add year to magazine template context
- Use self.year instead of year in magazine article view
- Check if magazine article subsection exists
- Rename section3.png to section3.jpg
- Add missing dash to magazine subsection images
- Silence a React `background-image` style prop error