### PR TITLE
fix os.path.join bug for env_file. use abs path

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -28,8 +28,9 @@ if not "GOOGLE_APPLICATION_CREDENTIALS" in os.environ:
     # We deal with this one environment variable without using the environ library, because we need it to be set prior to initializing the env object 
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = os.path.join(PROJECT_DIR, 'client-secret.json')
 
-# Look for the environment variables file in the project root directory
-env_file = os.path.join(PROJECT_DIR, '/tmp/.env')
+# Look for the environment variables file in the root directory
+# Absolute rather than relative path here, to play nice with Google App Engine
+env_file = os.path.join('/tmp/.env')
 
 #If we didn't find an .env file, we try to get one from Google Cloud. This requires authentication.
 if not os.path.isfile(env_file):


### PR DESCRIPTION
## What problem does this PR solve?

os.path.join(PROJECT_DIR, '/tmp/.env') was returning the absolute path '/tmp/.env' instead of what was expected; but coincidentally, this is the desirable behaviour

# How did you fix the problem?

Modify the code to os.path.join('/tmp/.env') to explicitly show intention to use absolute path '/tmp/.env' for readability. Should not change behaviour