### PR TITLE
very long Google App Engine static file caching

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -2,6 +2,8 @@ runtime: python37
 entrypoint: gunicorn -b :$PORT --chdir ubyssey/ wsgi:application
 instance_class: F4
 
+default_expiration: "365d"
+
 automatic_scaling:
   max_idle_instances: 2
   target_cpu_utilization: .9


### PR DESCRIPTION
## What problem does this PR solve?

Very short static file caching for GAE

## How did you fix the problem?

Set default for static file caching to 365 days