### PR TITLE
Remove trending functionality

### DIFF
--- a/ubyssey/templates/widgets/frontpage/default.html
+++ b/ubyssey/templates/widgets/frontpage/default.html
@@ -7,7 +7,7 @@
     <div class="frontpage">
       <div class="frontpage__columns">
         <div class="cell left">
-        {% if articles.trending %}
+        {% comment %} {% if articles.trending %}
           <div class="o-trending-article">
           {% with articles.trending as trending_article %}
             <span>
@@ -20,14 +20,14 @@
             </article>
           {% endwith %}
           </div>
-        {% else %}
-          {% with articles.secondary as article %}
-            <article class="secondary padded">
-                <h2 class="headline"><a href="{{ article.get_absolute_url }}?ref=frontpage">{{ article.headline|safe }}</a></h2>
-                <p class="o-article__snippet"><span class="timestamp">{{ article.published_at|naturaltime }}</span>{{ article.snippet|safe }}</p>
-            </article>
-          {% endwith %}
-        {% endif %}
+        {% else %} {% endcomment %}
+        {% with articles.secondary as article %}
+          <article class="secondary padded">
+              <h2 class="headline"><a href="{{ article.get_absolute_url }}?ref=frontpage">{{ article.headline|safe }}</a></h2>
+              <p class="o-article__snippet"><span class="timestamp">{{ article.published_at|naturaltime }}</span>{{ article.snippet|safe }}</p>
+          </article>
+        {% endwith %}
+        {% comment %} {% endif %} {% endcomment %}
         {% include 'objects/advertisement.html' with size='box' name='Box_A' class='mobile-frontpage-box' id=2 %}
         {% for article in articles.thumbs %}
             <article class="thumb row padded">

--- a/ubyssey/views/main.py
+++ b/ubyssey/views/main.py
@@ -62,7 +62,7 @@ class HomePageView(ArticleMixin, TemplateView):
         )
         frontpage = list(frontpage)
 
-        trending_article = self.get_trending()
+        # trending_article = self.get_trending()
         try:
             #TODO: fail more gracefully!
             articles = {
@@ -71,7 +71,7 @@ class HomePageView(ArticleMixin, TemplateView):
                 'thumbs': frontpage[2:4],
                 'bullets': frontpage[4:6],
                 # Get random trending article
-                'trending': trending_article,
+                # 'trending': trending_article,
                 'breaking': context['breaking']
              }
         except IndexError:


### PR DESCRIPTION
## What problem does this PR solve?

Trending article functionality depended upon broken "views" column which has now been removed. Commented out if-statements that depended upon it functioning normally