### PR TITLE
height now adjusts automatically

### DIFF
--- a/ubyssey/static_src/src/styles/modules/_homepage.scss
+++ b/ubyssey/static_src/src/styles/modules/_homepage.scss
@@ -130,6 +130,7 @@ div.frontpage {
       border-bottom: 1px dotted #C8C8C8;
       img {
         width: 100%;
+        height: auto;
       }
       h1 {
         margin-top: 15px;


### PR DESCRIPTION
## What problem does this PR solve?

Fixes issue #940 

<!--
    Reference the issue # if appropriate
-->

## How did you fix the problem?

Wagtail resize rules for width only was being overridden by css, but didn’t adjust height, which was causing the weird ratios.

Image height now set to auto.
This fix was documented to cause layout problems but we do not seem to have any at the moment.
[https://www.smashingmagazine.com/2020/03/setting-height-width-images-important-again/](https://www.smashingmagazine.com/2020/03/setting-height-width-images-important-again/)

<!--
    Include a summary of the change.
-->