### PR TITLE
Homepage image resizing problem

### DIFF
--- a/home/templates/home/objects/above_cut.html
+++ b/home/templates/home/objects/above_cut.html
@@ -28,7 +28,7 @@
                 <div class="image">
                     <a href={% pageurl article %}>
                       {% if article.featured_media.first.image %}
-                        {% image article.featured_media.first.image fill-250x250-c0 %}
+                        {% image article.featured_media.first.image fill-250x250 %}
                       {% elif article.featured_video %}
                         <img src="http://img.youtube.com/vi/{{ article.featured_video.video.url|youtube_embed_id|safe }}/0.jpg" alt=""/>
                       {% endif %}  
@@ -48,7 +48,7 @@
                   <div class="image">
                       <a href={% pageurl article %}>
                         {% if article.featured_media.first.image %}
-                          {% image article.featured_media.first.image fill-250x250-c0 %}
+                          {% image article.featured_media.first.image fill-250x250 %}
                         {% elif article.featured_video %}
                           <img src="http://img.youtube.com/vi/{{ article.featured_video.video.url|youtube_embed_id|safe }}/0.jpg" alt=""/>
                         {% endif %}  

--- a/home/templates/home/objects/above_cut.html
+++ b/home/templates/home/objects/above_cut.html
@@ -28,7 +28,7 @@
                 <div class="image">
                     <a href={% pageurl article %}>
                       {% if article.featured_media.first.image %}
-                        {% image article.featured_media.first.image fill-80x80 %}
+                        {% image article.featured_media.first.image fill-250x250-c0 %}
                       {% elif article.featured_video %}
                         <img src="http://img.youtube.com/vi/{{ article.featured_video.video.url|youtube_embed_id|safe }}/0.jpg" alt=""/>
                       {% endif %}  
@@ -48,7 +48,7 @@
                   <div class="image">
                       <a href={% pageurl article %}>
                         {% if article.featured_media.first.image %}
-                          {% image article.featured_media.first.image fill-80x80 %}
+                          {% image article.featured_media.first.image fill-250x250-c0 %}
                         {% elif article.featured_video %}
                           <img src="http://img.youtube.com/vi/{{ article.featured_video.video.url|youtube_embed_id|safe }}/0.jpg" alt=""/>
                         {% endif %}  
@@ -96,7 +96,7 @@
                 <article class="primary {{ article.template }}">
                     <a class="image" href={% pageurl article %}>
                       {% if article.featured_media.first.image %}
-                        {% image article.featured_media.first.image width-400 %}
+                        {% image article.featured_media.first.image width-480 %}
                       {% elif article.featured_video %} 
                         <img src="http://img.youtube.com/vi/{{ article.featured_video.video.url|youtube_embed_id|safe }}/0.jpg" alt=""/>
                       {% endif %}

--- a/home/templates/home/objects/above_cut.html
+++ b/home/templates/home/objects/above_cut.html
@@ -96,7 +96,7 @@
                 <article class="primary {{ article.template }}">
                     <a class="image" href={% pageurl article %}>
                       {% if article.featured_media.first.image %}
-                        {% image article.featured_media.first.image width-480 %}
+                        {% image article.featured_media.first.image width-715 %}
                       {% elif article.featured_video %} 
                         <img src="http://img.youtube.com/vi/{{ article.featured_video.video.url|youtube_embed_id|safe }}/0.jpg" alt=""/>
                       {% endif %}


### PR DESCRIPTION
## What problem does this PR solve?

Decreased quality of images in featured articles on homepage (frontpage).

<img width="1265" alt="Screen Shot 2022-03-07 at 19 46 43" src="https://user-images.githubusercontent.com/45521929/157162411-96031be2-46cb-4079-a093-41170bdecf62.png">

<!--
    Reference the issue # if appropriate
-->

## How did you fix the problem?

Centre image increased to width of 715 (approx/greater what should actually load).
Image fill increased to 250 by 250 for column on left (approx/greater than what should actually load).
So rendition phase of image captures better quality for use.

<!--
    Include a summary of the change.
-->