### PR TITLE
Added strikethrough, center align, right align

### DIFF
--- a/dashboard/wagtail_hooks.py
+++ b/dashboard/wagtail_hooks.py
@@ -7,3 +7,138 @@ from wagtail.core import hooks
 @hooks.register('insert_global_admin_css')
 def global_admin_css():
     return format_html('<link rel="stylesheet" href="{}">', static('css/custom.css'))
+
+
+import wagtail.admin.rich_text.editors.draftail.features as draftail_features
+from wagtail.admin.rich_text.converters.html_to_contentstate import InlineStyleElementHandler
+
+# 1. Use the register_rich_text_features hook.
+@hooks.register('register_rich_text_features')
+def register_strikethrough_feature(features):
+    """
+    Registering the `mark` feature, which uses the `MARK` Draft.js inline style type,
+    and is stored as HTML with a `<mark>` tag.
+    """
+    feature_name = 'strikethrough'
+    type_ = 'STRIKETHROUGH'
+    tag = 'strikethrough'
+
+    # 2. Configure how Draftail handles the feature in its toolbar.
+    control = {
+        'type': type_,
+        'label': 's',
+        'description': 'Strikethrough',
+        # This isn’t even required – Draftail has predefined styles for MARK.
+        # 'style': {'textDecoration': 'line-through'},
+    }
+
+    # 3. Call register_editor_plugin to register the configuration for Draftail.
+    features.register_editor_plugin(
+        'draftail', feature_name, draftail_features.InlineStyleFeature(control)
+    )
+
+    # 4.configure the content transform from the DB to the editor and back.
+    db_conversion = {
+        'from_database_format': {tag: InlineStyleElementHandler(type_)},
+        'to_database_format': {'style_map': {type_: tag}},
+    }
+
+    # 5. Call register_converter_rule to register the content transformation conversion.
+    features.register_converter_rule('contentstate', feature_name, db_conversion)
+
+    # 6. (optional) Add the feature to the default features list to make it available
+    # on rich text fields that do not specify an explicit 'features' list
+    features.default_features.append('strikethrough')
+
+from wagtail.admin.rich_text.converters.html_to_contentstate import BlockElementHandler
+@hooks.register("register_rich_text_features")
+def register_centertext_feature(features):
+    """Creates centered text in our richtext editor and page."""
+
+    # Step 1
+    feature_name = "center"
+    type_ = "CENTERTEXT"
+    tag = "div"
+
+    # Step 2
+    control = {
+        "type": type_,
+        "label": "Center",
+        "description": "Center Text",
+        "style": {
+            "display": "block",
+            "text-align": "center",
+        },
+    }
+
+    # Step 3
+    features.register_editor_plugin(
+        "draftail", feature_name, draftail_features.InlineStyleFeature(control)
+    )
+
+    # Step 4
+    db_conversion = {
+        "from_database_format": {tag: InlineStyleElementHandler(type_)},
+        "to_database_format": {
+            "style_map": {
+                type_: {
+                    "element": tag,
+                    "props": {
+                        "class": "d-block text-center"
+                    }
+                }
+            }
+        }
+    }
+
+    # Step 5
+    features.register_converter_rule("contentstate", feature_name, db_conversion)
+
+    # Step 6, This is optional.
+    features.default_features.append(feature_name)
+
+@hooks.register("register_rich_text_features")
+def register_righttext_feature(features):
+    """Creates centered text in our richtext editor and page."""
+
+    # Step 1
+    feature_name = "right"
+    type_ = "RIGHTTEXT"
+    tag = "div"
+
+    # Step 2
+    control = {
+        "type": type_,
+        "label": "Right",
+        "description": "Right Text",
+        "style": {
+            "display": "block",
+            "text-align": "right",
+        },
+    }
+
+    # Step 3
+    features.register_editor_plugin(
+        "draftail", feature_name, draftail_features.InlineStyleFeature(control)
+    )
+
+    # Step 4
+    db_conversion = {
+        "from_database_format": {tag: InlineStyleElementHandler(type_)},
+        "to_database_format": {
+            "style_map": {
+                type_: {
+                    "element": tag,
+                    "props": {
+                        "class": "d-block text-right"
+                    }
+                }
+            }
+        }
+    }
+
+    # Step 5
+    features.register_converter_rule("contentstate", feature_name, db_conversion)
+
+    # Step 6, This is optional.
+    features.default_features.append(feature_name)

--- a/dashboard/wagtail_hooks.py
+++ b/dashboard/wagtail_hooks.py
@@ -1,16 +1,14 @@
 from django.utils.html import format_html
 from django.templatetags.static import static
 
-
 from wagtail.core import hooks
+
+import wagtail.admin.rich_text.editors.draftail.features as draftail_features
+from wagtail.admin.rich_text.converters.html_to_contentstate import InlineStyleElementHandler
 
 @hooks.register('insert_global_admin_css')
 def global_admin_css():
     return format_html('<link rel="stylesheet" href="{}">', static('css/custom.css'))
-
-
-import wagtail.admin.rich_text.editors.draftail.features as draftail_features
-from wagtail.admin.rich_text.converters.html_to_contentstate import InlineStyleElementHandler
 
 # 1. Use the register_rich_text_features hook.
 @hooks.register('register_rich_text_features')
@@ -50,7 +48,6 @@ def register_strikethrough_feature(features):
     # on rich text fields that do not specify an explicit 'features' list
     features.default_features.append('strikethrough')
 
-from wagtail.admin.rich_text.converters.html_to_contentstate import BlockElementHandler
 @hooks.register("register_rich_text_features")
 def register_centertext_feature(features):
     """Creates centered text in our richtext editor and page."""


### PR DESCRIPTION
Issue: Feature request: Draftail Strikethrough #1002

Added strikethrough, centrer align, and right align to dashboard/wagtail_hooks.py
