### PR TITLE
homepage and article page image quality fix

### DIFF
--- a/article/templates/article/article_page.html
+++ b/article/templates/article/article_page.html
@@ -83,7 +83,7 @@
                                     {% with self.featured_media.first as featured_image_object %}
                                         <div class="featured-media">
                                             {% image featured_image_object.image original as original_image %}
-                                            {% image featured_image_object.image width-500 as featured_image %}
+                                            {% image featured_image_object.image width-700 as featured_image %}
                                             <img class="article-attachment" 
                                                 data-id="{{ featured_image_object.id }}"
                                                 data-caption="{% if featured_image_object.caption %}{{ featured_image_object.caption }}{% endif %}"

--- a/article/templates/article/objects/default.html
+++ b/article/templates/article/objects/default.html
@@ -7,7 +7,7 @@
   <div class="o-article__left">
     <a class="o-article__image" href={% pageurl article %}>
       {% if article.featured_media.first.image %}
-       {% image article.featured_media.first.image fill-340x238-c100 %}
+       {% image article.featured_media.first.image fill-680x476-c100 %}
       {% else %}
         <img src="http://img.youtube.com/vi/{{ article.featured_video.video.url|youtube_embed_id|safe }}/0.jpg" alt=""/>
       {% endif %}

--- a/article/templates/article/objects/featured.html
+++ b/article/templates/article/objects/featured.html
@@ -10,7 +10,7 @@
 	{% if article.featured_media.first.image %}
 	<div class="o-article__left">
 		<a class="o-article__image" href="{% pageurl article %}">
-			{% image article.featured_media.first.image fill-340x238-c100 %}
+			{% image article.featured_media.first.image fill-680x476-c100 %}
 		</a>
 	</div>
 	{% elif article.featured_media.first.video %}


### PR DESCRIPTION
## What problem does this PR solve?

Image quality issues on the homepage and the main photos within indiv article pages.

## How did you fix the problem?

Images were being loaded onto the page at one size [through Wagtail](https://docs.wagtail.org/en/stable/topics/images.html) and then resized through CSS (e.g. width: auto) to another, bigger size, causing the image quality issues.

Fixed through adjusting loaded sizes through Wagtail template.
