### PR TITLE
Add the image of the top left article to the homepage

### DIFF
--- a/home/templates/home/stream_blocks/above_cut_block.html
+++ b/home/templates/home/stream_blocks/above_cut_block.html
@@ -14,6 +14,16 @@
 				{% with articles.1 as article %}
 				{% if article %}
 				<article class="secondary padded">
+					<div class="image">
+						<a href={% pageurl article %}>
+							{% if article.featured_media.first.image %}
+							{% image article.featured_media.first.image fill-250x250 %}
+							{% elif article.featured_video %}
+							<img src="http://img.youtube.com/vi/{{ article.featured_video.video.url|youtube_embed_id|safe }}/0.jpg"
+								alt="" />
+							{% endif %}
+						</a>
+					</div>
 					<h2 class="headline"><a href={% pageurl article %}>{{ article.title|safe }}</a></h2>
 					<p class="o-article__snippet"><span
 							class="timestamp">{{ article.published_at|naturaltime }}</span>{{ article.lede|safe }}</p>


### PR DESCRIPTION
## What problem does this PR solve?

<!--
    Reference the issue # if appropriate
-->

## How did you fix the problem?

When the homepage is rendered the above cut stream html renders the first few articles. Most to all times the <article class="secondary padded"> is rendered first for the first article. Within this tag there is no <div class="image"> tag, therefore, no image is rendered to the top left article of the homepage. To fix the issue I have added an image div which is the same as the article tag with class thumb row padded to the article tag with class secondary padded.

Things we can also look at,
1. Are there any article tags that is loaded for the first top left article than secondary padded.
2. Do we want to change the structure of the article tag secondary padded?
3. Do we want to change the size of the image to make the image fit with the homepage layout?