### PR TITLE
Changed image format to webP

### DIFF
--- a/archive/templates/archive/objects/article_list.html
+++ b/archive/templates/archive/objects/article_list.html
@@ -9,7 +9,7 @@
 	<div class="o-article__left">
 		<a class="o-article__image" href="{% pageurl article %}">
 			{% if article.featured_media.first.image %}
-				{% image article.featured_media.first.image fill-340x238-c100 %}
+				{% image article.featured_media.first.image fill-340x238-c100 format-webp %}
 			{% elif article.featured_media.first.video %}
 			<img src="http://img.youtube.com/vi/{{ article.featured_media.first.video.url|youtube_embed_id|safe }}/0.jpg"
 				alt="Thumbnail" />

--- a/article/templates/article/article_page.html
+++ b/article/templates/article/article_page.html
@@ -82,8 +82,8 @@
                                 {% if self.featured_media.first.image %}
                                     {% with self.featured_media.first as featured_image_object %}
                                         <div class="featured-media">
-                                            {% image featured_image_object.image original as original_image %}
-                                            {% image featured_image_object.image width-500 as featured_image %}
+                                            {% image featured_image_object.image original format-webp as original_image %}
+                                            {% image featured_image_object.image width-500 format-webp as featured_image %}
                                             <img class="article-attachment" 
                                                 data-id="{{ featured_image_object.id }}"
                                                 data-caption="{% if featured_image_object.caption %}{{ featured_image_object.caption }}{% endif %}"

--- a/article/templates/article/article_page_fw_story.html
+++ b/article/templates/article/article_page_fw_story.html
@@ -34,7 +34,7 @@
         {% elif self.header_layout == 'banner-image' %}
             {% with self.featured_media.first as featured_image_object %}
                 <div class="banner-image">
-                    {% image featured_image_object.image original as featured_image %}
+                    {% image featured_image_object.image original format-webp as featured_image %}
                     <div class="backdrop" style="background-image: url('{{ featured_image.url }}');"></div>
                     <div class="headline-container">
                         <div class="u-container u-container--padded">

--- a/article/templates/article/article_page_guide_2020.html
+++ b/article/templates/article/article_page_guide_2020.html
@@ -8,7 +8,7 @@
         {% include 'objects/advertisement.html' with size='leaderboard' name='Leaderboard' id=1 article=self.id %}
         {% include 'objects/advertisement.html' with size='mobile-leaderboard' name='Mobile_Leaderboard' id=2 article=self.id %}
         {% with self.featured_media.first as featured_image_object %}
-            {% image featured_image_object.image original as featured_image %}
+            {% image featured_image_object.image original format-webp as featured_image %}
             <div class="c-banner c-banner--welcome" style="background-image: url('{{ featured_image.url }}');">
                 <div class="c-banner__container">
                     <div class="c-banner--welcome__inner">
@@ -82,9 +82,9 @@
                     <div class="c-up-next__arrow c-up-next__arrow--right"></div>
                 </div>
                 <div class="article-boxes">
-                    {% image prev.featured_media.first.image original as prev_image %}
+                    {% image prev.featured_media.first.image original format-webp as prev_image %}
                     {% include 'article/objects/guide/article-box2022.html' with style='article' title=prev.title page=prev image=prev_image.url %}
-                    {% image next.featured_media.first.image original as next_image %}
+                    {% image next.featured_media.first.image original format-webp as next_image %}
                     {% include 'article/objects/guide/article-box2022.html' with style='article' title=next.title page=next image=next_image.url %}
                 </div>
             </main>

--- a/article/templates/article/article_page_guide_2022.html
+++ b/article/templates/article/article_page_guide_2022.html
@@ -51,7 +51,7 @@
     {% endblock %}
 
     {% with self.featured_media.first as featured_image_object %}
-        {% image featured_image_object.image original as featured_image %}
+        {% image featured_image_object.image original format-webp as featured_image %}
         <div class="c-banner c-banner--welcome" style="background-image: url('{{ featured_image.url }}');">
             <div class="c-banner__container">
                 {% comment %} <div class="c-banner--welcome__inner">
@@ -82,9 +82,9 @@
                 </div>
             </div>
             <div class="article-boxes">
-                {% image prev.featured_media.first.image original as prev_image %}
+                {% image prev.featured_media.first.image original format-webp as prev_image %}
                 {% include 'article/objects/guide/article-box2022.html' with style='article' title=prev.title page=prev image=prev_image.url prevornext='prev' %}
-                {% image next.featured_media.first.image original as next_image %}
+                {% image next.featured_media.first.image original format-webp as next_image %}
                 {% include 'article/objects/guide/article-box2022.html' with style='article' title=next.title page=next image=next_image.url prevornext='next' %}
             </div>
         </main>

--- a/article/templates/article/article_page_magazine_2023.html
+++ b/article/templates/article/article_page_magazine_2023.html
@@ -60,8 +60,8 @@
                     {% if self.featured_media.first.image %}
                         {% with self.featured_media.first as featured_image_object %}
                             <div class="featured-media">
-                                {% image featured_image_object.image original as original_image %}
-                                {% image featured_image_object.image width-1000 as featured_image %}
+                                {% image featured_image_object.image original format-webp as original_image %}
+                                {% image featured_image_object.image width-1000 format-webp as featured_image %}
                                 <img class="article-attachment" 
                                     data-id="{{ featured_image_object.id }}"
                                     data-caption="{% if featured_image_object.caption %}{{ featured_image_object.caption }}{% endif %}"

--- a/article/templates/article/objects/blog_column.html
+++ b/article/templates/article/objects/blog_column.html
@@ -14,7 +14,7 @@ This template is for the columns for the blog section on the home page under the
       {% if article.featured_media.first %}
         {% if article.featured_media.first.image %}
           <a class="o-article__image" href="{% pageurl article %}">
-            {% image article.featured_media.first.image fill-250x250-c100 %}
+            {% image article.featured_media.first.image fill-75x75-c100 format-webp %}
           </a>
         {% elif article.featured_media.first.video %}
           <a class="o-article__image" href="{% pageurl article %}" style="background-image: url('http://img.youtube.com/vi/{{ article.featured_media.first.video.url|youtube_embed_id|safe }}/0.jpg'); background-size: contain; background-repeat: no-repeat"></a>

--- a/article/templates/article/objects/column.html
+++ b/article/templates/article/objects/column.html
@@ -10,7 +10,7 @@
         {% if article.featured_media.first %}
           {% if article.featured_media.first.image %}
             <a class="o-article__image" href="{% pageurl article %}">
-              {% image article.featured_media.first.image fill-250x250-c100 %}
+              {% image article.featured_media.first.image fill-75x75-c100 format-webp %}
             </a>
           {% elif article.featured_media.first.video %}
             <a class="o-article__image" href="{% pageurl article %}" style="background-image: url('http://img.youtube.com/vi/{{ article.featured_media.first.video.url|youtube_embed_id|safe }}/0.jpg'); background-size: contain; background-repeat: no-repeat"></a>

--- a/article/templates/article/objects/default.html
+++ b/article/templates/article/objects/default.html
@@ -7,7 +7,7 @@
   <div class="o-article__left">
     <a class="o-article__image" href={% pageurl article %}>
       {% if article.featured_media.first.image %}
-       {% image article.featured_media.first.image fill-340x238-c100 %}
+       {% image article.featured_media.first.image fill-340x238-c100 format-webp %}
       {% else %}
         <img src="http://img.youtube.com/vi/{{ article.featured_video.video.url|youtube_embed_id|safe }}/0.jpg" alt=""/>
       {% endif %}

--- a/article/templates/article/objects/featured.html
+++ b/article/templates/article/objects/featured.html
@@ -10,7 +10,7 @@
 	{% if article.featured_media.first.image %}
 	<div class="o-article__left">
 		<a class="o-article__image" href="{% pageurl article %}">
-			{% image article.featured_media.first.image fill-340x238-c100 %}
+			{% image article.featured_media.first.image fill-340x238-c100 format-webp %}
 		</a>
 	</div>
 	{% elif article.featured_media.first.video %}

--- a/article/templates/article/objects/fw_article_featured_media.html
+++ b/article/templates/article/objects/fw_article_featured_media.html
@@ -6,7 +6,7 @@
 
 {% if self.featured_media.first.image %}
     {% with self.featured_media.first as featured_image_object %}
-        {% image featured_image_object.image original as featured_image %}
+        {% image featured_image_object.image original format-webp as featured_image %}
         <img
             class="article-attachment"
             data-id="{{ featured_image_object.image.id }}"

--- a/article/templates/article/stream_blocks/gallery.html
+++ b/article/templates/article/stream_blocks/gallery.html
@@ -1,7 +1,7 @@
 {% load wagtailimages_tags %}
 <div id="gallery-{{ self.pk }}" data-id="{{ self.id }}" data-title="{{ self.title }}" class="gallery-attachment attachment">
     <div class="gallery-cover">
-        {% image self.gallery_images.all.0.image fill-800x600 as cover_image %}
+        {% image self.gallery_images.all.0.image fill-800x600 format-webp as cover_image %}
         <img class="gallery-thumb" data-id="{{ self.gallery_images.all.0.id }}" src="{{ cover_image.url }}" alt="Our gallery"/>
         <div class="meta row">
             <div class="eight columns">
@@ -19,7 +19,7 @@
                 {% comment %} do nothing, this is only for every image except the "cover" (first) image {% endcomment %}
             {% else %}
                 <li>
-                    {% image orderable.image fill-250x250 as thumb_image %}
+                    {% image orderable.image fill-250x250 format-webp as thumb_image %}
                     <div class="gallery-thumb" data-id="{{ orderable.pk }}" style="background-image: url('{{ thumb_image.url }}');" /></div>
                 </li>
             {% endif %}
@@ -27,7 +27,7 @@
     </ul>
     <div class="images">
         {% for orderable in self.gallery_images.all %}
-            {% image orderable.image fill-800x600 as image %}
+            {% image orderable.image fill-800x600 format-webp as image %}
             <div class="gallery-image" data-id="{{ orderable.pk }}" data-url="{{ image.url }}" {% if orderable.caption %}data-caption="{{ orderable.caption|safe }}"{% endif %}></div>
         {% endfor %}
     </div>

--- a/authors/templates/authors/author_page.html
+++ b/authors/templates/authors/author_page.html
@@ -16,7 +16,7 @@
 		<div class="c-page__header">
 			{% if self.image %}
 			<div class="c-page__header__thumbnail">
-				{% image self.image fill-150x200   %}
+				{% image self.image fill-150x200 format-webp  %}
 
 			</div>
 			{% endif %}

--- a/home/templates/home/stream_blocks/above_cut_block.html
+++ b/home/templates/home/stream_blocks/above_cut_block.html
@@ -31,7 +31,7 @@
 					<div class="image">
 						<a href={% pageurl article %}>
 							{% if article.featured_media.first.image %}
-							{% image article.featured_media.first.image fill-250x250 %}
+							{% image article.featured_media.first.image fill-250x250 format-webp %}
 							{% elif article.featured_video %}
 							<img src="http://img.youtube.com/vi/{{ article.featured_video.video.url|youtube_embed_id|safe }}/0.jpg"
 								alt="" />
@@ -53,7 +53,7 @@
 					<div class="image">
 						<a href={% pageurl article %}>
 							{% if article.featured_media.first.image %}
-							{% image article.featured_media.first.image fill-250x250 %}
+							{% image article.featured_media.first.image fill-250x250 format-webp %}
 							{% elif article.featured_video %}
 							<img src="http://img.youtube.com/vi/{{ article.featured_video.video.url|youtube_embed_id|safe }}/0.jpg"
 								alt="" />
@@ -103,7 +103,7 @@
 				<article class="primary {{ article.template }}">
 					<a class="image" href={% pageurl article %}>
 						{% if article.featured_media.first.image %}
-						{% image article.featured_media.first.image width-715 %}
+						{% image article.featured_media.first.image width-715 format-webp %}
 						{% elif article.featured_video %}
 						<img src="http://img.youtube.com/vi/{{ article.featured_video.video.url|youtube_embed_id|safe }}/0.jpg"
 							alt="" />

--- a/home/templates/home/stream_blocks/sidebar_image_link_block.html
+++ b/home/templates/home/stream_blocks/sidebar_image_link_block.html
@@ -2,7 +2,7 @@
 {% if self.link %}
     <a href={{ self.link }}>
 {% endif %}
-{% image self.image width-320 %}
+{% image self.image width-320 format-webp %}
 {% if self.link %}
     </a>
 {% endif %}

--- a/home/templates/home/stream_blocks/sidebar_single_issue_block.html
+++ b/home/templates/home/stream_blocks/sidebar_single_issue_block.html
@@ -1,2 +1,2 @@
 {% load wagtailimages_tags %}
-<h5 class="headline"{% if self.show_image and self.image %} id='issue-photo'{% endif %}><a class='issue' id ="issue{{ iteration }}" href={{ self.link }}>{{ self.date }}{% if self.show_image and self.image %}{% image self.image width-320 %}{% endif %}</a></h5>
+<h5 class="headline"{% if self.show_image and self.image %} id='issue-photo'{% endif %}><a class='issue' id ="issue{{ iteration }}" href={{ self.link }}>{{ self.date }}{% if self.show_image and self.image %}{% image self.image width-320 format-webp %}{% endif %}</a></h5>

--- a/images/templates/images/stream_blocks/image_block.html
+++ b/images/templates/images/stream_blocks/image_block.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
 <div class="image-attachment attachment {{ self.style }} {{ self.width }}" >
-    {% image self.image original as image %}
+    {% image self.image original format-webp as image %}
     <img class="article-attachment" data-id="{{ image.id }}" data-caption="{{ self.caption }}" data-credit="{{ self.credit }}" data-url="{{ image.url }}" src="{{ image.url }}" alt="{{ self.caption }}" />
     {% if self.caption or self.credit %}
         <div class="caption">

--- a/specialfeaturelanding/templates/specialfeaturelanding/blocks/guide-2020-panel-quote.html
+++ b/specialfeaturelanding/templates/specialfeaturelanding/blocks/guide-2020-panel-quote.html
@@ -5,7 +5,7 @@
     <div class="{{ self.class_name }}-container">
         <div class="{{ self.class_name }}-container-text">
             <div class="{{ self.class_name }}-container-image">
-                {% image self.image original as image %}
+                {% image self.image original format-webp as image %}
                 <img src="{{ image.url }}" alt="cover">
             </div>
             <div class="{{ self.class_name }}-text">

--- a/specialfeaturelanding/templates/specialfeaturelanding/blocks/guide-2021-banner.html
+++ b/specialfeaturelanding/templates/specialfeaturelanding/blocks/guide-2021-banner.html
@@ -1,7 +1,7 @@
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
 
-{% image self.image original as banner_image %}
+{% image self.image original format-webp as banner_image %}
 
 <div class="c-banner c-banner--welcome" style="background-image: url({{banner_image.url}})">
     <div class="c-banner__container">

--- a/specialfeaturelanding/templates/specialfeaturelanding/blocks/guide-banner-block.html
+++ b/specialfeaturelanding/templates/specialfeaturelanding/blocks/guide-banner-block.html
@@ -1,5 +1,5 @@
 {% load wagtailimages_tags %}
-{% image self.image original as banner_image %}
+{% image self.image original format-webp as banner_image %}
 
 <div class="c-banner c-banner--welcome"
 	style="background-image: url({{ banner_image.url }})">

--- a/specialfeaturelanding/templates/specialfeaturelanding/blocks/image-block.html
+++ b/specialfeaturelanding/templates/specialfeaturelanding/blocks/image-block.html
@@ -1,5 +1,5 @@
 {% load wagtailimages_tags %}
 
 <div class="{{ block.value.class_name }}">
-    {% image block.value.image %}
+    {% image block.value.image format-webp %}
 </div>

--- a/specialfeaturelanding/templates/specialfeaturelanding/blocks/mag_2023_card.html
+++ b/specialfeaturelanding/templates/specialfeaturelanding/blocks/mag_2023_card.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
-{% image self.card_image original as banner_image %}
+{% image self.card_image original format-webp as banner_image %}
 
 <div class="{{ self.class_name}}">
 

--- a/specialfeaturelanding/templates/specialfeaturelanding/blocks/rendition-fill-1200x1000.html
+++ b/specialfeaturelanding/templates/specialfeaturelanding/blocks/rendition-fill-1200x1000.html
@@ -1,3 +1,3 @@
 {% load wagtailimages_tags %}
-{% image self.image fill-1200x1000 as cover_photo %}
+{% image self.image fill-1200x1000 format-webp as cover_photo %}
 <img src="{{ cover_photo.url }}" alt="{{ cover_photo.alt }}" style="object-fit:cover;"/>

--- a/specialfeaturelanding/templates/specialfeaturelanding/blocks/textless_banner_block.html
+++ b/specialfeaturelanding/templates/specialfeaturelanding/blocks/textless_banner_block.html
@@ -1,4 +1,4 @@
 {% load wagtailimages_tags %}
-{% image self.image original as banner_image %}
+{% image self.image original format-webp as banner_image %}
 
 <img src="{{ banner_image.url }}" class= "{{ self.class_selector}}">

--- a/ubyssey/templates/404.html
+++ b/ubyssey/templates/404.html
@@ -17,7 +17,7 @@
             //DOES THIS NEED TO BE MODIFIED???
             //start {% endcomment %}
             <div class="image-attachment attachment {{ self.style }} {{ self.width }}" >
-                {% image self.image original as image %}
+                {% image self.image original format-webp as image %}
                 {% comment %} //img src and alt modified to be the image now added in the images folder
                 //what else needs to be changed {% endcomment %}
                 <img class="article-attachment" data-id="{{ image.id }}" data-caption="{{ self.caption }}" data-credit="{{ self.credit }}" data-url="{{ image.url }}" src="{% static 'images/404graphic.png' %}" alt="404 image" />

--- a/ubyssey/templates/ubyssey/archive.html
+++ b/ubyssey/templates/ubyssey/archive.html
@@ -70,7 +70,7 @@
                 <div class="o-article__left">
                   <a class="o-article__image" href={% pageurl article %}>
                     {% if article.featured_media.first.image %}
-                      {% image article.featured_media.first.image fill-340x238-c100 %}
+                      {% image article.featured_media.first.image fill-340x238-c100 format-webp %}
                     {% else %}
                       <img src="http://img.youtube.com/vi/{{ article.featured_media.first.video.url|youtube_embed_id|safe }}/0.jpg" width=300 alt="" />
                     {% endif %}


### PR DESCRIPTION
## What problem does this PR solve?

The webP format has higher compression than png. Using it significantly improves the lighthouse report

I also made the column images in the homepage a lower resolution because they were much too high for the small size they were displayed at.