### PR TITLE
Added the redirect from blog to humour

### DIFF
--- a/ubyssey/urls.py
+++ b/ubyssey/urls.py
@@ -3,12 +3,13 @@ from django.urls import include, path, re_path
 from django.conf.urls.static import static
 from django.contrib.staticfiles.views import serve as serve_static
 from django.contrib import admin
+from django.shortcuts import redirect
 
 from dispatch.urls import admin_urls, api_urls, podcasts_urls
 from newsletter.urls import urlpatterns as newsletter_urls
 
 from ubyssey.views.feed import FrontpageFeed, SectionFeed
-from ubyssey.views.main import ads_txt, UbysseyTheme, HomePageView, ArticleView, SectionView, SubsectionView, VideoView, PageView, PodcastView, ArticleAjaxView, AuthorView, ArchiveView, IsolationView
+from ubyssey.views.main import ads_txt,redirect_blog_to_humour, UbysseyTheme, HomePageView, ArticleView, SectionView, SubsectionView, VideoView, PageView, PodcastView, ArticleAjaxView, AuthorView, ArchiveView, IsolationView
 from ubyssey.views.guide import guide2016, GuideArticleView, GuideLandingView
 
 from ubyssey.views.advertise import AdvertiseTheme
@@ -68,6 +69,7 @@ urlpatterns += [
     # Wagtail
     re_path(r'^admin/', include(wagtailadmin_urls)),
     re_path(r'^documents/', include(wagtaildocs_urls)),
+    re_path(r'^blog/', redirect_blog_to_humour),
     path('', include(wagtail_urls)),
 
     # # standard Ubyssey site

--- a/ubyssey/views/main.py
+++ b/ubyssey/views/main.py
@@ -26,6 +26,9 @@ def parse_int_or_none(maybe_int):
 def ads_txt(request):
     return redirect(settings.ADS_TXT_URL)
 
+def redirect_blog_to_humour(request):
+    path = request.get_full_path().replace("/blog/","/humour/")
+    return redirect(path)
 
 class HomePageAJAX(TemplateView):
     """


### PR DESCRIPTION
## What problem does this PR solve?

Editors want to rename blog to humour. Changing the slug would cause link rot for blog articles. This redirect would prevent the link rot