### PR TITLE
1113 redirect blog to humour samlow

### DIFF
--- a/section/models.py
+++ b/section/models.py
@@ -183,7 +183,8 @@ class SectionPage(RoutablePageMixin, SectionablePage):
     
     def get_section_articles(self, order='-explicit_published_at') -> QuerySet:
         # return ArticlePage.objects.from_section(section_root=self)
-        section_articles = ArticlePage.objects.live().public().filter(current_section=self.slug).order_by(order)
+        # section_articles = ArticlePage.objects.live().public().filter(current_section=self.slug).order_by(order)
+        section_articles = ArticlePage.objects.live().public().descendant_of(self).order_by(order)
         return section_articles
 
     def get_featured_articles(self, queryset=None, number_featured=4) -> QuerySet:

--- a/ubyssey/urls.py
+++ b/ubyssey/urls.py
@@ -3,12 +3,13 @@ from django.urls import include, path, re_path
 from django.conf.urls.static import static
 from django.contrib.staticfiles.views import serve as serve_static
 from django.contrib import admin
+from django.shortcuts import redirect
 
 from dispatch.urls import admin_urls, api_urls, podcasts_urls
 from newsletter.urls import urlpatterns as newsletter_urls
 
 from ubyssey.views.feed import FrontpageFeed, SectionFeed
-from ubyssey.views.main import ads_txt, UbysseyTheme, HomePageView, ArticleView, SectionView, SubsectionView, VideoView, PageView, PodcastView, ArticleAjaxView, AuthorView, ArchiveView, IsolationView
+from ubyssey.views.main import ads_txt,redirect_blog_to_humour, UbysseyTheme, HomePageView, ArticleView, SectionView, SubsectionView, VideoView, PageView, PodcastView, ArticleAjaxView, AuthorView, ArchiveView, IsolationView
 from ubyssey.views.guide import guide2016, GuideArticleView, GuideLandingView
 
 from ubyssey.views.advertise import AdvertiseTheme
@@ -68,6 +69,7 @@ urlpatterns += [
     # Wagtail
     re_path(r'^admin/', include(wagtailadmin_urls)),
     re_path(r'^documents/', include(wagtaildocs_urls)),
+    re_path(r'^blog/', redirect_blog_to_humour),
     path('', include(wagtail_urls)),
 
     # # standard Ubyssey site

--- a/ubyssey/views/main.py
+++ b/ubyssey/views/main.py
@@ -26,6 +26,9 @@ def parse_int_or_none(maybe_int):
 def ads_txt(request):
     return redirect(settings.ADS_TXT_URL)
 
+def redirect_blog_to_humour(request):
+    path = request.get_full_path().replace("/blog/","/humour/")
+    return redirect(path)
 
 class HomePageAJAX(TemplateView):
     """


### PR DESCRIPTION
## What problem does this PR solve?

Editors wish to rename the blog section to humour. Changing the slug would cause linkrot and also prevent all previous articles from being retrieved in the section page.

## How did you fix the problem?

To prevent link rot I created a redirect  for requests to /blog/... to /humour/...

To fix the way sectionpage retrieves articlesI had it relied on the page hierarchy (parent/child pages) rather than the field "current_section" which will become out of date when the slug is changed
