### PR TITLE
Updated newsletter link

### DIFF
--- a/newsletter/views.py
+++ b/newsletter/views.py
@@ -5,7 +5,7 @@ from django.shortcuts import redirect
 from django.views.generic import View
 
 def mailchimp_landing_redirect(self):
-    response = redirect('https://mailchi.mp/8c879257bf61/subscribe-to-our-newsletter')
+    response = redirect('https://embeds.beehiiv.com/8cc31358-f28d-486d-b3ad-99cdf843ce88')
     return response
 
 # class WebhookResponseHandlerView(View):    

--- a/ubyssey/static_src/src/js/components/Cookies/CookieDisclaimer.jsx
+++ b/ubyssey/static_src/src/js/components/Cookies/CookieDisclaimer.jsx
@@ -49,7 +49,7 @@ class CookieDisclaimer extends React.Component {
                 <p>
                   This website uses cookies to give you the best experience possible.
                   Using this website means you accept our use of cookies. You can disable cookies in your browser settings.
-                  We respect your privacy and you can read more about our cookie policy <em><a href={'https://www.ubyssey.ca/page/cookie-policy-2020/'}>here</a></em>.
+                  We respect your privacy and you can read more about our cookie policy <em><a href={'https://www.ubyssey.ca/pages/cookie-policy-2020/'}>here</a></em>.
                 </p>
                 <button
                   className='c-button c-button--small'


### PR DESCRIPTION
`ubyssey.ca/newsletter` would redirect the user to our old newsletter provider. This branch updates it to the new newsletter provider. After this is merged we should change the `newsletter` link in the main menu to link to `ubyssey.ca/newsletter`