### PR TITLE
1170 archive page bugs akshanjay

### DIFF
--- a/archive/models.py
+++ b/archive/models.py
@@ -348,7 +348,11 @@ class ArchivePage(RoutablePageMixin, Page):
                 articles = articles | ArticlePage.objects.from_section(section_slug=sections[0].slug).live().public()
         else:
             sections = SectionPage.objects.filter(categories__slug=spoof_slug).live().public()
-            articles = ArticlePage.objects.from_section(section_slug=sections[0].slug).live().public()
+            if sections[0].title.capitalize() != "Humor" :
+                articles = ArticlePage.objects.from_section(section_slug=sections[0].slug).live().public()
+            else:
+                articles = ArticlePage.objects.live().public().filter(category__slug=spoof_slug)   
+
         
         if context["order"]:
             articles = self.get_order_objects(context["order"], articles, video_section)           

--- a/archive/templates/archive/objects/archive_filter.html
+++ b/archive/templates/archive/objects/archive_filter.html
@@ -37,8 +37,8 @@
     </div>
 
     <div class="o-archive__sidebar__filters">
-        <h2>Section</h2>
-        <ul>
+        <h2>Section <a href="#" class="filterDropdown"><i class="fa-solid fa-caret-down"></i></a></h2>
+        <ul class="hide_filter">
             <li
                 class="o-archive__sidebar__filter{% if section_slug == "All" %} o-archive__sidebar__filter--is-active{% endif %}">
                 <a href="{% pageurl self %}{{ request|query_string }}">All sections</a>

--- a/ubyssey/static_src/src/styles/objects/_archive.scss
+++ b/ubyssey/static_src/src/styles/objects/_archive.scss
@@ -78,7 +78,7 @@ $search-bar-height: 46px;
 		// Structure
 		display: block;
 		height: fit-content;
-		position: sticky;
+		position: static;
 		top: 50px;
 	}
 }


### PR DESCRIPTION
## What problem does this PR solve?

1. Fixes the issues where the spoof articles in the humour section does not show up in the archive results. It instead shows all the humour articles.
2. Fixes the section filter not having a dropdown
3. Fixes the issue whether filter sidebar is moving down with the archive results and does not stay in one place.