### PR TITLE
Fix special article page

### DIFF
--- a/article/templates/article/article_like_special_page.html
+++ b/article/templates/article/article_like_special_page.html
@@ -18,13 +18,13 @@
             <h1>{{ page.title }}</h1>
         </div>
         <div class="u-container">
-            <div class="row">
-                <div class="seven columns article-content">
+            <div class="flex">
+                <div class="seven article-content">
                         {% for block in self.content %}
                             {% include_block block with id=block.id %}
                         {% endfor %}                        
                 </div>
-                <aside class="five columns">
+                <aside class="five">
                     {% comment %}ad goes here{% endcomment %}
                     {% for right_column_block in self.right_column_content %}
                         {% include_block right_column_block with id=block.id %}

--- a/ubyssey/static_src/src/styles/main.scss
+++ b/ubyssey/static_src/src/styles/main.scss
@@ -251,6 +251,10 @@ a.image {
   }
 }
 
+.flex {
+  display: flex;
+}
+
 .hide {
 	display: none;
 }


### PR DESCRIPTION
The footer would raise to the top of the article and block other elements from being clicked on or highlight. I fixed this by making the container a flex box