### PR TITLE
Fixed spacing in articles

### DIFF
--- a/ubyssey/static_src/src/styles/modules/article/_base.scss
+++ b/ubyssey/static_src/src/styles/modules/article/_base.scss
@@ -382,7 +382,6 @@ div.article-content {
     @media($bp-larger-than-phablet){
       padding: 0;
       max-width: 585px;
-      margin: auto;
     }
   }
 


### PR DESCRIPTION
I removed a `margin: auto` which overwrote the margins of certain elements inside `article-content`