### PR TITLE
Fixed the authors search filed

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -913,6 +913,8 @@ class ArticlePage(RoutablePageMixin, SectionablePage, UbysseyMenuMixin):
         index.RelatedFields('article_authors', [
             index.SearchField('full_name'),
         ]),
+        
+        index.FilterField('author_id')
     ]
 
     #-----Properties, getters, setters, etc.-----


### PR DESCRIPTION
## What problem does this PR solve?

#1243 

## How did you fix the problem?

Added a `index.SearchField('author_id')` to allow author_id field to be used in the search field.