### PR TITLE
Fixed quote block issue

### DIFF
--- a/article/templates/article/stream_blocks/quote.html
+++ b/article/templates/article/stream_blocks/quote.html
@@ -13,7 +13,7 @@
             {% if self.source %}<span class="source">Listen to {{ self.source }}</span>{% endif %}
         </a>
     {% elif self.source %}
-        <span class="source">Listen to {{ self.source }}</span>
+        <span class="source">— {{ self.source }}</span>
     {% endif %}
     </p>
 </div>


### PR DESCRIPTION
The quote block was saying "Listen to [source]" even when there was no audio. I replaced "Listen to" to a dash