### PR TITLE
Fixed order filter

### DIFF
--- a/archive/templates/archive/objects/archive.html
+++ b/archive/templates/archive/objects/archive.html
@@ -23,12 +23,12 @@
 					{% if page_obj %} {{ page_obj.paginator.count }} RESULTS {% else %}NO RESULTS{% endif %}
 					{% if q %} FOR "{{ q }}"{% endif %}
 				</h3>
-				<div class="o-archive__header__sort o-dropdown js-dropdown">
+				<div class="o-archive__header__sort o-dropdown">
 					<a class="o-button o-dropdown__button" href="#">
 						<span>{{ order|title }}</span>
 						<i class="fa fa-sort-desc"></i>
 					</a>
-					<ul class="o-dropdown__list js-dropdown-list">
+					<ul class="o-dropdown__list">
 						<li class="o-dropdown__item{% if order == 'newest' %} o-dropdown__item--is-active{% endif %}">
 							<a href="?{% modify_query_string 'order' 'newest' %}">Newest</a>
 						</li>

--- a/authors/models.py
+++ b/authors/models.py
@@ -236,6 +236,12 @@ class AuthorPage(RoutablePageMixin, Page):
         context["media_types"] = media_types
         context["media_type"] = self.main_media_type
 
+        order = request.GET.get("order")
+        if order == 'oldest':
+            context["order"] = "Oldest"
+        else:            
+            context['order'] = 'Newest'
+
         context = self.organize_media(self.main_media_type, request, context)
 
         return context

--- a/ubyssey/static_src/src/styles/objects/_inputs.scss
+++ b/ubyssey/static_src/src/styles/objects/_inputs.scss
@@ -77,6 +77,14 @@
 
 }
 
+.o-dropdown {
+	&:focus-within {
+		.o-dropdown__list {
+			display: block;
+		}
+	}
+}
+
 .o-dropdown__item {
 
   a {


### PR DESCRIPTION
The 'order' filter on the archive page would not dissapear when it was unfocused on. I fixed this by moving the mechanism out of javascript and into scss. I also added the label for the order filter to the authors page