### PR TITLE
Fixed the about page (sorry for breaking it)

### DIFF
--- a/article/templates/article/article_like_special_page.html
+++ b/article/templates/article/article_like_special_page.html
@@ -18,13 +18,13 @@
             <h1>{{ page.title }}</h1>
         </div>
         <div class="u-container">
-            <div class="flex">
-                <div class="seven article-content">
+            <div class="article-like-special-page">
+                <div class="article-content">
                         {% for block in self.content %}
                             {% include_block block with id=block.id %}
                         {% endfor %}                        
                 </div>
-                <aside class="five">
+                <aside>
                     {% comment %}ad goes here{% endcomment %}
                     {% for right_column_block in self.right_column_content %}
                         {% include_block right_column_block with id=block.id %}

--- a/ubyssey/static_src/src/styles/main.scss
+++ b/ubyssey/static_src/src/styles/main.scss
@@ -25,6 +25,7 @@
 @import 'modules/article/gallery';
 @import 'modules/article/full_width';
 @import 'modules/article/sidebar';
+@import 'modules/article/special_page.scss';
 @import 'modules/social';
 @import 'modules/search';
 
@@ -249,10 +250,6 @@ a.image {
   .dropdown-hidden {
     display: none;
   }
-}
-
-.flex {
-  display: flex;
 }
 
 .hide {

--- a/ubyssey/static_src/src/styles/modules/article/_special_page.scss
+++ b/ubyssey/static_src/src/styles/modules/article/_special_page.scss
@@ -1,31 +1,40 @@
 // Special article-like page
 @import 'modules/variables';
 
-.page > .u-container > .row {
+.article-like-special-page {
+
+  display: flex;
+  flex-direction: column;
+  @media($bp-larger-than-phablet){
+    flex-direction: row;
+    padding-left: 20px;
+    padding-right: 20px;
+  }
 
   // Left column (content)
-  .seven.columns {
-    display: table-cell;
-    vertical-align: top;
-    box-sizing: border-box;
-    height: auto;
+  .article-content {
     padding: 0 20px 0 0;
   }
 
   // Right column (sidebar)
-  aside.five {
-    display: table-cell;
-    vertical-align: top;
-    box-sizing: border-box;
+  aside {
     margin-left: 0px;
-    padding-left: 20px;
 
-    border-left: 1px solid $color-border-gray-light;
-
-    :first-child {
-      margin-top: 5px;
+    @media($bp-smaller-than-phablet){
+      padding-left: 10px;
+      border: none;
     }
 
+    @media($bp-larger-than-phablet){
+      padding-left: 20px;
+      width: 40%;
+  
+      border-left: 1px solid $color-border-gray-light;
+  
+      :first-child {
+        margin-top: 5px;
+      }  
+    }
   }
 }
 


### PR DESCRIPTION
The about page and the navigation shared the useage of a class `.row`. I changed this class when I redid the nav and that messed up the about page template.  I tried fixing it before but I didn't do a good job and forgot to look at how it scaled for mobile (it didn't). This time I went to the wayback machine and tried to recreate the look (but updated the css to using flex boxes because tables are no longer recomended for design outside of making a table)