### PR TITLE
removed used of bs prettify function

### DIFF
--- a/ads/templatetags/ubyssey_ad_filters.py
+++ b/ads/templatetags/ubyssey_ad_filters.py
@@ -47,7 +47,7 @@ def inject_ads(value, is_mobile):
                 ad_string = render_to_string('ads/advertisement_inline.html', context=ad_context)
                 paragraphs[n].insert_after(BeautifulSoup(ad_string, 'html.parser'))
 
-    return soup.prettify()
+    return soup
 
 @register.filter(name='specify_homepage_sidebar_ads')
 @stringfilter


### PR DESCRIPTION
Ads used to be inserted by finding `</p>` tags and inserting the html before them. This interfered with the visual essay so I changed it to only being inserted in `p` tags when they are direct children of `.article-content`

I then returned the html by using `soup.prettify()`. `prettify` "cleans up" html and it added these annoying spaces at the end of innerHTML of elements including anchor tags. This extended the anchor tags underline which looked ugly.

To fix this I just returned `soup` instead of `soup.prettify()` 