### PR TITLE
Added a case for when the pubdate is None

### DIFF
--- a/article/templatetags/articletags.py
+++ b/article/templatetags/articletags.py
@@ -34,6 +34,10 @@ def get_section_title(value):
 
 @register.filter(name='display_pubdate')
 def display_pubdate(value):
+
+    if value == None:
+        return "Unknown"
+
     timedif = datetime.timedelta(hours=-7)
 
     pubdate = value + timedif


### PR DESCRIPTION
Some articles have the publish date as None by accident. The django tag for formating the publish date did not have a case for this which resulted in an error. In this pull request I added a Nonetype case to avoid the error