### PR TITLE
Prefetch featured images to reduce number of database queries

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -416,7 +416,12 @@ class ArticlePageTag(TaggedItemBase):
 
 #-----Manager models-----
 class ArticlePageManager(PageManager):
-    
+
+    def get_queryset(self):
+        return super() \
+            .get_queryset() \
+            .prefetch_related('featured_media__image')
+
     def from_section(self, section_slug='', section_root=None) -> QuerySet:
         from .models import ArticlePage
         from section.models import SectionPage

--- a/article/models.py
+++ b/article/models.py
@@ -418,6 +418,12 @@ class ArticlePageTag(TaggedItemBase):
 class ArticlePageManager(PageManager):
 
     def get_queryset(self):
+        """
+        Extend the default queryset to prefetch featured images for all articles.
+
+        This significantly reduces the number of database queries on pages that list
+        a large number of articles.
+        """
         return super() \
             .get_queryset() \
             .prefetch_related('featured_media__image')


### PR DESCRIPTION
## What problem does this PR solve?

Closes #1331

## How did you fix the problem?

I extended the default article queryset to prefetch featured images. This ensures that prefetching is enabled for all article queries, although it may sometimes fetch featured images when none are needed (e.g. when rendering a list of articles without their images).

|Page|Queries before|Queries after|
|-----|---------------|-------------|
|Home page|649|487|
|Article page|231|185|