### PR TITLE
Enable Django cache in production

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -234,17 +234,21 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'wagtail.contrib.settings.context_processors.settings',
                 'wagtailmenus.context_processors.wagtailmenus',
+                'config.context_processors.get_light_mode',
             ],
             'loaders': [
-                'django.template.loaders.filesystem.Loader',
-                'django.template.loaders.app_directories.Loader',
-                'dbtemplates.loader.Loader',
+                (
+                    'django.template.loaders.cached.Loader',
+                    [
+                        'django.template.loaders.filesystem.Loader',
+                        'django.template.loaders.app_directories.Loader',
+                        'dbtemplates.loader.Loader',
+                    ],
+                ),
             ],
         },
     }
 ]
-
-TEMPLATES[0]['OPTIONS']['context_processors'].append("config.context_processors.get_light_mode")
 
 # REST framework settings
 REST_FRAMEWORK = {

--- a/config/settings/development.py
+++ b/config/settings/development.py
@@ -11,12 +11,11 @@ ALLOWED_HOSTS = ['localhost', '*']
 
 INTERNAL_IPS = ['127.0.0.1', '0.0.0.0', 'localhost']
 
-# Easily manipulable file cache for proof of concept for front page etc.
+# The dummy cache does not cache any values. We use this in development
+# so that the website always updates after code changes.
 CACHES = {
     "default": {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
-        # "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
-        # "LOCATION": "/workspaces/ubyssey.ca/cache/",
     }
 }
 

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -20,13 +20,11 @@ INSTALLED_APPS += [
 # Sessions are used to anonymously keep track of individual site visitors
 SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 
-# Caches are used to store the results of SQL queries so it can be quickly retrieved and needs to do less work
-# The cache requires a Memcached instance be set up in Google Cloud Platform (GCP) and access connectors to be set both on GCP and in app.yaml
+# TODO: replace this cache backend with a distributed solution like Memcached or Redis.
+# For now, use the default local memory cache.
 CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
-        # 'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
-        # 'LOCATION': '10.18.240.4:11211',
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
     }
 }
 


### PR DESCRIPTION
## What problem does this PR solve?

Closes #1332 

On the homepage, this reduces the number of database queries from 640 to 503.

## How did you fix the problem?

- Replaced `DummyCache` with `LocMemCache`. This is the default cached that Django uses if none is specified.
- Added the `django.template.loaders.cached.Loader` template loader. Django caches templates by default but only if `loaders` isn't specified, so we need to explicitly configure it in our settings.