### PR TITLE
Add Redis cache

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -84,11 +84,15 @@ env = environ.Env(
     USE_TZ=(bool,True),
     TIME_ZONE=(str,'Canada/Pacific'),
 
-    # Database defaults:
+    # SQL defaults
     SQL_HOST = (str, 'db'),
-    SQL_DATABASE= (str, 'ubyssey'),
+    SQL_DATABASE = (str, 'ubyssey'),
     SQL_USER = (str, 'root'),
     SQL_PASSWORD = (str, 'ubyssey'),
+
+    # Redis defaults
+    REDIS_HOST = (str, '127.0.0.1'),
+    REDIS_PORT = (str, '6379'),
 
     # Keys
     SECRET_KEY = (str, 'thisisakey'),
@@ -114,6 +118,9 @@ STATIC_URL = env('STATIC_URL')
 MEDIA_URL = env('MEDIA_URL')
 ADS_TXT_URL = env('ADS_TXT_URL')
 ROOT_URLCONF = env('ROOT_URLCONF')
+
+REDIS_HOST = env('REDIS_HOST')
+REDIS_PORT = env('REDIS_PORT')
 
 # Initialize the databases.
 # Note it should be possible to parse all this information in a single line:

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -25,6 +25,9 @@ SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 # We previously used the Memcache service bundled with Google App Engine,
 # but it is now considered a legacy service and does not work seamlessly with Django.
 #
+# TODO: switch to built-in Redis backend after upgrading Django.
+# Ref: https://github.com/ubyssey/ubyssey.ca/issues/1340
+#
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -19,6 +19,12 @@ INSTALLED_APPS += []
 # Sessions are used to anonymously keep track of individual site visitors
 SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 
+# We use Redis as a cache backend, as recommended by Wagtail here:
+# https://docs.wagtail.org/en/v2.10.2/advanced_topics/performance.html#cache
+#
+# We previously used the Memcache service bundled with Google App Engine,
+# but it is now considered a legacy service and does not work seamlessly with Django.
+#
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -6,7 +6,7 @@ from google.oauth2 import service_account
 
 import environ
 
-env = environ.Env() #Scope issues without this line?
+env = environ.Env() # Scope issues without this line?
 
 BASE_URL = 'https://www.ubyssey.ca/'
 
@@ -14,22 +14,21 @@ ALLOWED_HOSTS = ['localhost', '*']
 
 INTERNAL_IPS = ['127.0.0.1', '0.0.0.0', 'localhost']
 
-INSTALLED_APPS += [
-]
+INSTALLED_APPS += []
 
 # Sessions are used to anonymously keep track of individual site visitors
 SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 
-# TODO: replace these cache backends with a persistent solution like Memcached or Redis.
-# For now, use the default local memory cache.
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://%s:%s" % (REDIS_HOST, REDIS_PORT), 
     },
     # The "renditions" cache is for Wagtail image renditions.
     # Ref: https://docs.wagtail.org/en/v2.10.2/advanced_topics/performance.html#caching-image-renditions
     "renditions": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://%s:%s" % (REDIS_HOST, REDIS_PORT),
     }
 }
 

--- a/requirements-prd.txt
+++ b/requirements-prd.txt
@@ -27,3 +27,6 @@ wagtailmenus==3.0.2
 wagtail-cache==1.0.2
 google-crc32c==1.3.0
 wagtail-color-panel==1.4.0
+django-redis==5.4.0
+redis==5.0.1
+hiredis==2.2.3


### PR DESCRIPTION
## What problem does this PR solve?

Closes #1332 

This PR adds configuration for a Redis cache in production.

Note: we will need to set the `REDIS_HOST` and `REDIS_PORT` environment variables in production before deploying this change.