### PR TITLE
Used proper timezone maybe?

### DIFF
--- a/article/templatetags/articletags.py
+++ b/article/templatetags/articletags.py
@@ -1,4 +1,5 @@
 from django import template
+from django.utils import timezone
 from django.template.defaultfilters import stringfilter
 from django.template.loader import render_to_string
 from section.models import SectionPage
@@ -38,10 +39,8 @@ def display_pubdate(value):
     if value == None:
         return "Unknown"
 
-    timedif = datetime.timedelta(hours=-7)
-
-    pubdate = value + timedif
-    today = datetime.datetime.now().replace(tzinfo=datetime.timezone(timedif)) + timedif
+    pubdate = value
+    today = timezone.now
     delta = today - pubdate
 
     if delta.total_seconds() > datetime.timedelta(days=365).total_seconds():

--- a/article/templatetags/articletags.py
+++ b/article/templatetags/articletags.py
@@ -40,7 +40,7 @@ def display_pubdate(value):
         return "Unknown"
 
     pubdate = value
-    today = timezone.now
+    today = timezone.now()
     delta = today - pubdate
 
     if delta.total_seconds() > datetime.timedelta(days=365).total_seconds():


### PR DESCRIPTION
When I wrote the new template tag for displaying the date, I stupidly forgot to consider that a timezone's relationship with UTC is not static. In vancouver it changes twice a year because of daylight savings time! So now all the articles say they are published in the future due to the offset.

I think I might have fixed it in this branch but I have no clue if this works yet since I can't test. 