### PR TITLE
bumping django google storage to 1.14.2

### DIFF
--- a/requirements-prd.txt
+++ b/requirements-prd.txt
@@ -1,6 +1,6 @@
 Django==3.2.11
 wagtail==3.0.0
-django-storages[google]==1.12
+django-storages[google]==1.14.2
 django-canonical-domain==0.3.0
 pymemcache==4.0.0
 mysqlclient==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==3.2.11
 wagtail==3.0.0
 git+https://github.com/ubyssey/django-google-storage.git@v0.5.4#egg=django-google-storage-updated
-django-storages[google]==1.13.2
+django-storages[google]==1.14.2
 django-canonical-domain==0.3.0
 pymemcache==4.0.0
 mysqlclient==2.0.1


### PR DESCRIPTION
## What problem does this PR solve?
Incompatibility with django google storage solution and latest updates to wagtail and python
