### PR TITLE
set up wagtailsearch_backends

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -322,6 +322,13 @@ WAGTAILIMAGES_IMAGE_MODEL = 'images.UbysseyImage'
 WAGTAILMENUS_ACTIVE_CLASS = 'current' # used for css in e.g. navigation/header.html
 WAGTAILMENUS_ACTIVE_ANCESTOR_CLASS = 'current'
 
+# wagtail search settings
+WAGTAILSEARCH_BACKENDS = {
+    'default': {
+        'BACKEND': 'wagtail.search.backends.database',
+    }
+}
+
 # Model defaults
 DEFAULT_AUTO_FIELD='django.db.models.AutoField'
 


### PR DESCRIPTION
## What problem does this PR solve?

"The following search back-ends (configured in WAGTAILSEARCH_BACKENDS) have been deprecated:"
https://docs.wagtail.org/en/stable/releases/2.15.html#database-search-backends-replaced

The search function was not working as intended due to deprecation and needed to have wagtail settings updated and the index rebuilt for the site.