### PR TITLE
unindex queried archive pages

### DIFF
--- a/archive/models.py
+++ b/archive/models.py
@@ -161,6 +161,9 @@ class ArchivePage(RoutablePageMixin, Page):
         context['q'] = search_query
         context['meta'] = { 'title': 'Archive' }
 
+        if search_query!=None or self.year!=None:
+            context['self'].noindex = True
+
         return context
     
     def get_paginated_articles(self, context, objects, video_section, request):


### PR DESCRIPTION
Queries in the archive page should not be showing up in search engines. It clogs results and I think it also increases the amount of requests we get from bots. This pr adds noindex to aarchive pages where there is a search query or a year filter