### PR TITLE
add both mobile and desktop ads to template, change inline ad styling

### DIFF
--- a/ads/templates/ads/advertisement_inline.html
+++ b/ads/templates/ads/advertisement_inline.html
@@ -1,7 +1,7 @@
 <div class="o-article-embed o-article-embed--advertisement">
     <div class="o-article-embed__advertisement">
-        <div class="o-advertisement o-advertisement--{{size}} o-advertisement--center">
-            <div class="adslot" id="{{ div_id }}" data-size="{{ size }}" data-dfp="{{ dfp }}">
+        <div class="o-advertisement o-advertisement--banner o-advertisement--center">
+            <div class="adslot" id="{{ div_id }}" data-size="banner" data-dfp="{{ dfp }}">
                 {% comment %}
                     See: 
                     https://developers.google.com/publisher-tag/guides/get-started
@@ -13,5 +13,19 @@
                 </script>          
             </div>
         </div>
+
+        <div class="o-advertisement o-advertisement--mobile-leaderboard o-advertisement--center">
+            <div class="adslot" id="{{ div_id }}" data-size="mobile-leaderboard" data-dfp="{{ dfp }}">
+                {% comment %}
+                    See: 
+                    https://developers.google.com/publisher-tag/guides/get-started
+                {% endcomment %}
+                <script>
+                    googletag.cmd.push(function() {
+                    googletag.display('{{ div_id }}');
+                    });
+                </script>          
+            </div>
+        </div>       
     </div>
 </div>

--- a/ubyssey/static_src/src/styles/modules/_advertisements.scss
+++ b/ubyssey/static_src/src/styles/modules/_advertisements.scss
@@ -143,6 +143,10 @@ main.article .o-advertisement--leaderboard {
     width: $width;
     height: $height;
   }
+
+  @media($bp-smaller-than-phablet) {
+    display: none;
+  }
 }
 
 .o-advertisement--box {

--- a/ubyssey/static_src/src/styles/modules/article/_embeds.scss
+++ b/ubyssey/static_src/src/styles/modules/article/_embeds.scss
@@ -29,9 +29,9 @@
 }
 
 .o-article-embed__advertisement {
-  padding: 10px;
+  // padding: 10px;
   display: inline-block;
-  background: #f9f9f9;
+  border: 1px solid #9e9e9e;
 
   .o-advertisement {
     margin-top: 10px;


### PR DESCRIPTION
When we build the template for articlepages we run a django template filter `ubyssey_ad_filters.py` which inserts ads between the p tags. The size of the ads is determined by checking the user agent so that we insert mobile sized ads (mobile leaderboard) when the user is on a mobile device and desktop sized (banner) when the user is on desktop. 

After the template is built for the first time, caching saves the rendered page and delivers it without having to rebuild again. This means desktop versions of the page which desktop ads can be delivered to users on mobile devices and vice verca. This could ruined the page size on mobile or have the ads not show on desktop. 

To fix this I added both ad sizes to the template and determine if they are displayed through media queries in the style sheet.