### PR TITLE
Store static files in Google Cloud Storage

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,5 +1,13 @@
-lib/PIL*
-lib/django/
+lib
 .git
 ^(.*/)?.*\.pyc
-ubyssey/static/
+
+ubyssey/static
+ubyssey/static_src
+
+bin
+cache
+.env
+
+static
+!static/staticfiles.json

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -144,8 +144,7 @@ NOTIFICATION_KEY = env('NOTIFICATION_KEY')
 # Application definition
 INSTALLED_APPS = [
 
-    # 'whitenoise.runserver_nostatic', # uncomment for testing "production-like" serving of collected static files with DEBUG=False
-    'ubyssey', #For some reason using ubyssey.apps.UbysseyConfig breaks static file finding?
+    'ubyssey', # For some reason using ubyssey.apps.UbysseyConfig breaks static file finding?
     'users',
     'home',
     'archive',
@@ -283,7 +282,6 @@ MIDDLEWARE = [
     'wagtailcache.cache.UpdateCacheMiddleware',
 
     'canonical_domain.middleware.CanonicalDomainMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.gzip.GZipMiddleware',
 ]
 
@@ -325,15 +323,10 @@ PHONENUMBER_DEFAULT_REGION = 'CA'
 
 PASSWORD_RESET_TIMEOUT_DAYS = 1
 
-# STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
-WHITENOISE_KEEP_ONLY_HASHED_FILES = True
 
 WAGTAIL_SITE_NAME = 'The Ubyssey'
-
 WAGTAILIMAGES_IMAGE_MODEL = 'images.UbysseyImage'
-
 
 # wagtailmenus settings
 WAGTAILMENUS_ACTIVE_CLASS = 'current' # used for css in e.g. navigation/header.html

--- a/config/settings/development.py
+++ b/config/settings/development.py
@@ -37,13 +37,12 @@ TEMPLATES += [
     }
 ]
 
-# STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+DEFAULT_FILE_STORAGE = 'ubyssey.storage.GCSMediaStorage'
+STATICFILES_STORAGE = 'ubyssey.storage.GCSStaticFilesStorage'
 
-GCS_CREDENTIALS_FILE = '../gcs-local.json'
-
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+GS_BUCKET_NAME = 'ubyssey'
+GS_QUERYSTRING_AUTH = False
+GS_FILE_OVERWRITE = False
 
 GCS_CREDENTIALS_FILE = '../gcs-local.json'
 

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -32,29 +32,13 @@ CACHES = {
 
 ADS_TXT_URL = 'https://ubyssey.storage.googleapis.com/ads.txt'
 
-# GCS File Storage - Production Only
-MEDIA_URL = 'https://ubyssey.storage.googleapis.com/media/'
-MEDIA_ROOT = ''
-DEFAULT_FILE_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
-GS_ACCESS_KEY_ID = env('GS_ACCESS_KEY_ID')
-GS_SECRET_ACCESS_KEY = env('GS_SECRET_ACCESS_KEY')
-# GS_CREDENTIALS = service_account.Credentials.from_service_account_file('ubyssey-prd-ee6290e6327f.json')
-# GS_CREDENTIALS = env('GOOGLE_APPLICATION_CREDENTIALS')
+DEFAULT_FILE_STORAGE = 'ubyssey.storage.GCSMediaStorage'
+STATICFILES_STORAGE = 'ubyssey.storage.GCSStaticFilesStorage'
+
 GS_BUCKET_NAME = 'ubyssey'
-GS_LOCATION = 'media'
 GS_QUERYSTRING_AUTH = False
 GS_FILE_OVERWRITE = False
 
-# Facebook - Production Only
-FACEBOOK_CLIENT_ID = env('FACEBOOK_CLIENT_ID')
-FACEBOOK_CLIENT_SECRET = env('FACEBOOK_CLIENT_SECRET')
-
-# Emails - Production Only
-EMAIL_HOST = env('EMAIL_HOST')
-EMAIL_PORT = 465
-EMAIL_HOST_USER = env('EMAIL_HOST_USER')
-EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD')
-EMAIL_USE_SSL = True
 UBYSSEY_ADVERTISING_EMAIL = env('UBYSSEY_ADVERTISING_EMAIL')
 
 # Use in-memory file handler on Google App Engine

--- a/requirements-prd.txt
+++ b/requirements-prd.txt
@@ -19,7 +19,6 @@ google-cloud-storage==1.44.0
 google-cloud-secret-manager==2.11.0
 django-environ==0.10.0
 requests==2.31.0
-whitenoise==6.5.0
 brotli==1.0.9
 django-extensions==3.2.3
 git+https://github.com/jazzband/django-dbtemplates.git@233a401#egg=django-dbtemplates

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Django==3.2.11
 wagtail==3.0.0
-git+https://github.com/ubyssey/django-google-storage.git@v0.5.4#egg=django-google-storage-updated
 django-storages[google]==1.14.2
 django-canonical-domain==0.3.0
 pymemcache==4.0.0
@@ -20,7 +19,6 @@ google-cloud-storage==1.44.0
 google-cloud-secret-manager==2.11.0
 django-environ==0.10.0
 requests==2.31.0
-whitenoise==6.5.0
 brotli==1.0.9
 django-extensions==3.2.3
 git+https://github.com/jazzband/django-dbtemplates.git@233a401#egg=django-dbtemplates

--- a/ubyssey/storage.py
+++ b/ubyssey/storage.py
@@ -1,0 +1,40 @@
+from django.contrib.staticfiles.storage import ManifestFilesMixin
+
+from storages.backends.gcloud import GoogleCloudStorage
+
+# TODO: Replace or remove these classes after upgrading to Django > 4.2.
+#
+# These custom wrapper classes are a workaround to allow
+# static files and media files to be stored in different
+# subfolders (i.e. locations) in the same GCS bucket.
+#
+# In Django 4.2 and above, it is possible to configure
+# static file storage separately from default storage.
+#
+# Ref: https://django-storages.readthedocs.io/en/latest/backends/gcloud.html#configuration-settings
+
+class GCSStaticFilesStorage(ManifestFilesMixin, GoogleCloudStorage):
+    """
+    This class wraps the GoogleCloudStorage class to add manifest support
+    and define a unique storage location (i.e. 'static').
+
+    Ref: https://docs.djangoproject.com/en/5.0/ref/contrib/staticfiles/#manifeststaticfilesstorage
+    """
+
+    # Store all static files in the 'static' directory
+    LOCATION = 'static'
+
+    def __init__(self):
+        super().__init__(location=GCSStaticFilesStorage.LOCATION)
+
+class GCSMediaStorage(GoogleCloudStorage):
+    """
+    This class wraps the GoogleCloudStorage class to define a
+    unique storage location (i.e. 'media').
+    """
+
+    # Store all files in the 'media' directory
+    LOCATION = 'media'
+
+    def __init__(self):
+        super().__init__(location=GCSMediaStorage.LOCATION)


### PR DESCRIPTION
## What problem does this PR solve?

The Ubyssey app currently uses Whitenoise to serve static files directly from App Engine, but this adds some overhead, especially on instance initialization. 

## How did you fix the problem?

I'd like to experiment with serving static files from Google Cloud Storage to see if it has a noticeable impact on site performance.

## TODO

I've got this code working in a sandboxed App Engine project, but we likely need to make tweaks to the GitHub Actions `release` workflow to ensure that static files are uploaded to the Ubyssey production bucket.