### PR TITLE
Split out visual bylines

### DIFF
--- a/archive/templates/archive/objects/archive.html
+++ b/archive/templates/archive/objects/archive.html
@@ -42,7 +42,11 @@
 			<div class="o-archive__main__list">
 				{% for object in page_obj %}
 					{% if video_section == False or video_section == None %}
-						{% include 'archive/objects/article_list.html' with article=object %}
+						{% if is_orderable %}
+							{% include 'archive/objects/article_list.html' with article=object.article_page %}
+						{% else %}
+							{% include 'archive/objects/article_list.html' with article=object %}
+						{% endif %}
 					{% else %}
 						{% include 'videos/stream_blocks/video.html' with video=object %}
 					{% endif %}

--- a/archive/templates/archive/objects/article_list.html
+++ b/archive/templates/archive/objects/article_list.html
@@ -23,9 +23,9 @@
 				<a href="{% pageurl article %}">{{ article.title|safe }}</a>
 			</h3>
 			<div class="o-article__byline">
-				<span class="o-article__author">By {{ article.get_authors_with_urls|safe }}</span>
+				<span class="o-article__author">{{article.authors_with_roles |safe }}</span>
 				<span> &nbsp;·&nbsp; </span>
-				<span class="o-article__published">{{ article.first_published_at|naturaltime }}</span>
+				<span class="o-article__published">{{ article.explicit_published_at|naturaltime }}</span>
 			</div>
 		</div>
 		{% if not hide_snippet %}

--- a/article/templates/article/objects/cover_story.html
+++ b/article/templates/article/objects/cover_story.html
@@ -25,7 +25,7 @@
     <div class="o-article__meta">
       <p class="o-article__snippet">{% if article.lede %}{{article.lede|safe}}{% else %}{{article.search_description|safe}}{% endif %}</p>
       <div class="o-article__byline">
-        <span class="o-article__author">{% if article.get_authors_with_urls %}{{article.get_authors_with_urls|safe }}{% else %}Ubyssey Staff{% endif %}</span>
+        <span class="o-article__author">{% if article.get_authors_split_out_visual_bylines %}{{article.authors_split_out_visual_bylines |safe }}{% else %}Ubyssey Staff{% endif %}</span>
         <span> &nbsp;&nbsp; </span>
         <a href="{{article|get_section_link}}" class="o-article__section-tag" style="background-color: {{article|get_colour}}">{{article|get_section_title}}</a>
         <span> &nbsp;&nbsp; </span>

--- a/article/templates/article/objects/infinitefeed_item.html
+++ b/article/templates/article/objects/infinitefeed_item.html
@@ -43,7 +43,7 @@
 			</h2>
 			<p class="o-article__snippet">{{ article.lede|safe }}</p>
 			<p class="o-article__byline">
-				<span class="o-article__author">{{ article.get_authors_with_urls|safe }}</span>
+				<span class="o-article__author">{{ article.get_authors_split_out_visual_bylines|safe }}</span>
 				<span> &nbsp;&nbsp; </span>
 				<span class="o-article__published">{{ article.explicit_published_at|display_pubdate }}</span>
 			</p>

--- a/article/templates/article/objects/top_article.html
+++ b/article/templates/article/objects/top_article.html
@@ -41,7 +41,7 @@
         <a href="{% pageurl article %}">{{ article.title|safe }}</a>
       </h2>
       <div class="o-article__byline">
-        <span class="o-article__author">{{ article.get_authors_with_urls|safe }}</span>
+        <span class="o-article__author">{{ article.get_authors_split_out_visual_bylines|safe }}</span>
         <span> &nbsp;&nbsp; </span>
         <span class="o-article__published">{{ article.explicit_published_at|display_pubdate }}</span>
       </div>

--- a/authors/templates/authors/author_page.html
+++ b/authors/templates/authors/author_page.html
@@ -51,20 +51,14 @@
 		{% endif %}
 		
 		<div class="options">
-			{% if "articles" in media_types %}
-				<h2 class="author-heading {% if media_type == "articles" %}selected{% endif %}"><a href="/authors/{{self.slug}}/articles">Articles</a></h2>
-			{% endif %}
-			{% if "photos" in media_types %}
-				<h2 class="author-heading {% if media_type == "photos" %}selected{% endif %}"><a href="/authors/{{self.slug}}/photos">Photos</a></h2>
-			{% endif %}
-			{% if "videos" in media_types %}
-				<h2 class="author-heading {% if media_type == "videos" %}selected{% endif %}"><a href="/authors/{{self.slug}}/videos">Videos</a></h2>
-			{% endif %}
+			{% for type in media_types %}
+				<h2 class="author-heading {% if media_type == type.0 %}selected{% endif %}"><a href="/authors/{{self.slug}}/{{type.0}}/">{{type.1}}</a></h2>
+			{% endfor %}
 		</div>
 
-		<h2 class="author-heading">Latest {{media_type}} from {{self.title}}</h2>
-		
-		{% if media_type == "articles" %}
+		<h2 class="author-heading">Latest {{media_type_name}} from {{self.title}}</h2>
+
+		{% if media_type == "articles" or media_type == "visual-bylines" %}
 			{% include 'archive/objects/archive.html' with page_obj=paginated_articles %}
 		{% elif media_type == "photos" %}
 			{% include 'archive/objects/gallery.html' with page_obj=paginated_articles %}

--- a/authors/templates/authors/author_page.html
+++ b/authors/templates/authors/author_page.html
@@ -59,7 +59,7 @@
 		<h2 class="author-heading">Latest {{media_type_name}} from {{self.title}}</h2>
 
 		{% if media_type == "articles" or media_type == "visual-bylines" %}
-			{% include 'archive/objects/archive.html' with page_obj=paginated_articles %}
+			{% include 'archive/objects/archive.html' with page_obj=paginated_articles current_page_articles=current_page_articles %}
 		{% elif media_type == "photos" %}
 			{% include 'archive/objects/gallery.html' with page_obj=paginated_articles %}
 		{% elif media_type == "videos" %}

--- a/ubyssey/static_src/src/styles/components/_author-page.scss
+++ b/ubyssey/static_src/src/styles/components/_author-page.scss
@@ -100,7 +100,11 @@
     }
 }
 .author-heading {
+    white-space: nowrap;
     font-size: 1.2rem;
+}
+.options .author-heading {
+    text-transform: capitalize;
 }
 .options {
     display: flex;

--- a/ubyssey/static_src/src/styles/components/_section-page.scss
+++ b/ubyssey/static_src/src/styles/components/_section-page.scss
@@ -138,6 +138,9 @@
   @media($bp-smaller-than-phablet) {
     display: block;
   }
+  .o-archive__search__input {
+    width: 115px;
+  }
 }
 
 .c-section__button-label {

--- a/ubyssey/static_src/src/styles/objects/_archive.scss
+++ b/ubyssey/static_src/src/styles/objects/_archive.scss
@@ -4,7 +4,6 @@ $search-bar-height: 50px;
   // Structure
   position: relative;
   margin-bottom: 1rem;
-  width:fit-content;
   flex-grow: 1;
 }
 
@@ -21,7 +20,7 @@ $search-bar-height: 50px;
 
 .o-archive__search__input {
   // Structure
-  width: 115px;
+  width: 180px;
   padding-left: $search-bar-height;
   padding-right: 1rem;
   box-sizing: border-box;
@@ -30,6 +29,7 @@ $search-bar-height: 50px;
   border: none;
   border-bottom: 1px solid;
   border-color: #ffffff00;
+  border-radius: 0;
 
   // Background
   background: none;
@@ -45,9 +45,10 @@ $search-bar-height: 50px;
   &:focus {
 	border-color: var(--header_color);
     outline: 0;
-	width:100%;
+	width:100% !important;
 	opacity: 1;
 	color: $color-accent-blue;
+	cursor: text;
   }
 
   &::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */


### PR DESCRIPTION
1. Separate tab in authors page for visual bylines
2. New author string function that separates out writers and visuals when there are visual only bylines

- Changes suggested by Iman yesterday for "workflow and ethical considerations"