### PR TITLE
Primary tag as dropdown

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -26,6 +26,7 @@ from modelcluster.contrib.taggit import ClusterTaggableManager
 from section.sectionable.models import SectionablePage
 
 from taggit.models import TaggedItemBase
+from taggit.models import Tag
 
 from videos import blocks as video_blocks
 from wagtail.contrib.routable_page.models import RoutablePageMixin, route
@@ -61,6 +62,9 @@ from wagtail_color_panel.edit_handlers import NativeColorPanel
 
 
 UBYSSEY_FOUNDING_DATE = datetime.date(1918,10,17)
+
+
+all_tags = (list(map(lambda tag: (tag.slug, tag.name), list(Tag.objects.all()))))    
 
 #-----Mixins-----
 class UbysseyMenuMixin(models.Model):
@@ -410,6 +414,11 @@ class ArticlePageTag(TaggedItemBase):
     class Meta:
         verbose_name = "article tag"
         verbose_name_plural = "article tags"
+
+class TagsFieldPanel(FieldPanel):
+    class BoundPanel(FieldPanel.BoundPanel):
+        class Media:
+            js = ["ubyssey/js/widgets/tags-panel.js"]    
 
 #-----Manager models-----
 class ArticlePageManager(PageManager):
@@ -782,8 +791,13 @@ class ArticlePage(RoutablePageMixin, SectionablePage, UbysseyMenuMixin):
             [
                 # FieldPanel("section"),
                 FieldPanel("category_page"),
-                FieldPanel("tags"),
-                FieldPanel("primary_tag_slug"),
+                TagsFieldPanel("tags"),
+                FieldPanel(
+                    "primary_tag_slug",
+                    widget=Select(
+                        choices=all_tags,
+                    ),
+                ),
                 FieldPanel("tag_page_link"),
                 FieldPanel("filter_by_tags"),
             ],
@@ -1012,7 +1026,6 @@ class ArticlePage(RoutablePageMixin, SectionablePage, UbysseyMenuMixin):
         All the below code occurs after the user submits a request and before they receive it.
         Therefore, keep the length of this method to a minimum; otherwise users will be kept waiting
         """
-        from taggit.models import Tag
 
         context = super().get_context(request, *args, **kwargs)
 
@@ -1284,6 +1297,10 @@ class ArticlePage(RoutablePageMixin, SectionablePage, UbysseyMenuMixin):
         tag = Tag.objects.get(slug=self.primary_tag_slug)
         return "<a href='/tag/" + tag.slug + "/'>" + tag.name + "</a>"
     primary_tag_link = property(fget=get_primary_tag_link)
+
+    def primary_tag_options(self):
+        print(self.tags())
+        return self.tags()
 
     @property
     def published_at(self):

--- a/article/models.py
+++ b/article/models.py
@@ -61,10 +61,7 @@ from wagtail_color_panel.fields import ColorField
 from wagtail_color_panel.edit_handlers import NativeColorPanel
 
 
-UBYSSEY_FOUNDING_DATE = datetime.date(1918,10,17)
-
-
-all_tags = (list(map(lambda tag: (tag.slug, tag.name), list(Tag.objects.all()))))    
+UBYSSEY_FOUNDING_DATE = datetime.date(1918,10,17) 
 
 #-----Mixins-----
 class UbysseyMenuMixin(models.Model):
@@ -416,9 +413,25 @@ class ArticlePageTag(TaggedItemBase):
         verbose_name_plural = "article tags"
 
 class TagsFieldPanel(FieldPanel):
+    '''
+    Adds the javascript that fills the dropdown based on the contents of the tag field
+    '''
     class BoundPanel(FieldPanel.BoundPanel):
         class Media:
             js = ["ubyssey/js/widgets/tags-panel.js"]    
+
+class PrimaryTagSelect(Select):
+    '''
+    Bizzare roundabout way to add the value of the field as one of the choices.
+    slightly altered method of ChoiceWidget found here: https://github.com/django/django/blob/main/django/forms/widgets.py
+    '''
+    def optgroups(self, name, value, attrs=None):
+        # Add value of primary tag field as one of the choices
+        if len(value) > 0:
+            if Tag.objects.filter(slug=value[0]).exists():
+                self.choices.append((value[0], Tag.objects.get(slug=value[0]).name))
+
+        return super().optgroups(name, value, attrs)  
 
 #-----Manager models-----
 class ArticlePageManager(PageManager):
@@ -794,9 +807,7 @@ class ArticlePage(RoutablePageMixin, SectionablePage, UbysseyMenuMixin):
                 TagsFieldPanel("tags"),
                 FieldPanel(
                     "primary_tag_slug",
-                    widget=Select(
-                        choices=all_tags,
-                    ),
+                    widget=PrimaryTagSelect(),
                 ),
                 FieldPanel("tag_page_link"),
                 FieldPanel("filter_by_tags"),

--- a/article/signals.py
+++ b/article/signals.py
@@ -2,6 +2,7 @@ from django.db.models.signals import pre_save, post_save, post_delete
 from django.dispatch import receiver
 from wagtail.signals import page_published
 from .models import ArticlePage
+from taggit.models import Tag
 
 @receiver(page_published, sender=ArticlePage)
 def update_default_explicit_published_at(instance, **kwargs):
@@ -10,6 +11,15 @@ def update_default_explicit_published_at(instance, **kwargs):
         for author in instance.article_authors.all():
             author.author.last_activity = instance.first_published_at
             author.author.save()
+        instance.save()
+
+@receiver(page_published, sender=ArticlePage)
+def update_primary_tag(instance, **kwargs):
+    if not Tag.objects.filter(slug=instance.primary_tag_slug).exists():
+        if Tag.objects.filter(name=instance.primary_tag_slug).exists():
+            instance.primary_tag_slug = Tag.objects.get(name=instance.primary_tag_slug).slug
+        else:
+            instance.primary_tag_slug = ""
         instance.save()
 
 @receiver(pre_save, sender=ArticlePage)

--- a/article/signals.py
+++ b/article/signals.py
@@ -3,6 +3,7 @@ from django.dispatch import receiver
 from wagtail.signals import page_published
 from .models import ArticlePage
 from taggit.models import Tag
+from django.utils.text import slugify
 
 @receiver(page_published, sender=ArticlePage)
 def update_default_explicit_published_at(instance, **kwargs):
@@ -15,12 +16,22 @@ def update_default_explicit_published_at(instance, **kwargs):
 
 @receiver(page_published, sender=ArticlePage)
 def update_primary_tag(instance, **kwargs):
-    if not Tag.objects.filter(slug=instance.primary_tag_slug).exists():
-        if Tag.objects.filter(name=instance.primary_tag_slug).exists():
-            instance.primary_tag_slug = Tag.objects.get(name=instance.primary_tag_slug).slug
-        else:
-            instance.primary_tag_slug = ""
-        instance.save()
+    '''
+    On new tags, the primary tag field is set to the name of the tag 
+    instead of the slug because the slug is not defined until after
+    the page is published. So after we published and the tag is created,
+    we set the primary tag field to the slug using this receiver.
+    '''
+    if not Tag.objects.filter(slug=instance.primary_tag_slug).exists() and instance.primary_tag_slug!="":
+        tag = None
+        if Tag.objects.filter(slug=slugify(instance.primary_tag_slug)).exists():
+            tag =Tag.objects.get(slug=slugify(instance.primary_tag_slug))
+        elif Tag.objects.filter(name=instance.primary_tag_slug).exists():
+            tag =Tag.objects.get(name=instance.primary_tag_slug)
+            
+        if tag:
+            instance.primary_tag_slug = tag.slug
+            instance.save()
 
 @receiver(pre_save, sender=ArticlePage)
 def update_timeline_on_article_alteration_pre_save(instance, **kwargs):

--- a/ubyssey/static_src/src/js/widgets/tags-panel.js
+++ b/ubyssey/static_src/src/js/widgets/tags-panel.js
@@ -23,6 +23,9 @@ function waitForElm(selector) {
 }
 
 function redoPrimaryTagSelection(){
+    // Empties the primary tag dropdown and then fills it back up from the value of primaryTagOptions. 
+    // Keeps same selected value if any.
+
     const select = document.getElementById("id_primary_tag_slug"); 
     let selected = Array.from(select.children).filter((child) => child.hasAttribute("selected")).map((child) => child.value);
     select.innerHTML = "";
@@ -45,10 +48,15 @@ function redoPrimaryTagSelection(){
 waitForElm('#id_tags').then((elem) => {
     waitForElm('#id_primary_tag_slug').then((elem) => {
         setTimeout(() => {
-            const primaryTags = Array.from($('#id_tags').tagit("instance").tagList.children()).map((tag) => tag.children[0].innerText.replaceAll('"', ""));
-            primaryTagOptions = Array.from(elem.children).filter((child) => primaryTags.includes(child.innerText)).map((child) => [child.value, child.innerText]);
+            // Read all tags from the tags field
+            const tags = Array.from($('#id_tags').tagit("instance").tagList.children()).map((tag) => tag.children[0].innerText.replaceAll('"', "")).filter((tag) => tag!="");
+           
+            // Start primaryTagOptions as everything in the primary tag dropdown. Then remove everything that isn't in the tags field.
+            // This is somewhat redundant as the dropdown should start either be empty or include only the saved value (which should already be chosen from the tags field)
+            primaryTagOptions = Array.from(elem.children).filter((child) => tags.includes(child.innerText)).map((child) => [child.value, child.innerText]);
             
-            for (tag of primaryTags) {
+            // Add every tag of the tags field that wasn't already in the primary tags dropdown
+            for (const tag of tags) {
                 if (primaryTagOptions.filter((t) => t.includes(tag)).length == 0) {
                     primaryTagOptions.push([tag, tag]);
                 }
@@ -56,11 +64,15 @@ waitForElm('#id_tags').then((elem) => {
             
             redoPrimaryTagSelection();
         
+            // callbacks are defined here:  https://github.com/wagtail/wagtail/blob/main/wagtail/admin/static_src/wagtailadmin/js/vendor/tag-it.js
+            
+            // When a tag is removed, remove it from the dropdown
             $('#id_tags').tagit({"afterTagRemoved": function(event, tag) {
                 primaryTagOptions = primaryTagOptions.filter((t) => !t.includes(tag.tagLabel));
                 redoPrimaryTagSelection();
             }});
             
+            // When a tag is added, add it to the dropdown
             $('#id_tags').tagit({"afterTagAdded": function(event,tag) {
                 if (primaryTagOptions.filter((t) => t.includes(tag.tagLabel)).length == 0) {
                     primaryTagOptions.push([tag.tagLabel, tag.tagLabel]);

--- a/ubyssey/static_src/src/js/widgets/tags-panel.js
+++ b/ubyssey/static_src/src/js/widgets/tags-panel.js
@@ -46,8 +46,6 @@ waitForElm('#id_tags').then((elem) => {
     waitForElm('#id_primary_tag_slug').then((elem) => {
         setTimeout(() => {
             const primaryTags = Array.from($('#id_tags').tagit("instance").tagList.children()).map((tag) => tag.children[0].innerText.replaceAll('"', ""));
-            console.log(primaryTags);
-            console.log(Array.from(elem.children).map((child) => [child.value, child.innerText]));
             primaryTagOptions = Array.from(elem.children).filter((child) => primaryTags.includes(child.innerText)).map((child) => [child.value, child.innerText]);
             
             for (tag of primaryTags) {
@@ -56,21 +54,22 @@ waitForElm('#id_tags').then((elem) => {
                 }
             }
             
-            console.log(primaryTagOptions);
             redoPrimaryTagSelection();
+        
+            $('#id_tags').tagit({"afterTagRemoved": function(event, tag) {
+                primaryTagOptions = primaryTagOptions.filter((t) => !t.includes(tag.tagLabel));
+                redoPrimaryTagSelection();
+            }});
+            
+            $('#id_tags').tagit({"afterTagAdded": function(event,tag) {
+                if (primaryTagOptions.filter((t) => t.includes(tag.tagLabel)).length == 0) {
+                    primaryTagOptions.push([tag.tagLabel, tag.tagLabel]);
+                    redoPrimaryTagSelection()
+                }
+            }});
+        
         }, 100);
 
     });
-
-    $('#id_tags').tagit({"afterTagRemoved": function(event, tag) { 
-        primaryTagOptions = primaryTagOptions.filter((t) => !t.includes(tag.tagLabel));
-        redoPrimaryTagSelection();
-    }});
-
-    $('#id_tags').tagit({"afterTagAdded": function(event,tag) {
-        if (primaryTagOptions.filter((t) => t.includes(tag.tagLabel)).length == 0) {
-            primaryTagOptions.push([tag.tagLabel, tag.tagLabel]);
-            redoPrimaryTagSelection()
-        }
-    }});
+    
 });

--- a/ubyssey/static_src/src/js/widgets/tags-panel.js
+++ b/ubyssey/static_src/src/js/widgets/tags-panel.js
@@ -1,0 +1,76 @@
+let primaryTagOptions = [];
+
+function waitForElm(selector) {
+    // Source: https://stackoverflow.com/a/61511955
+    return new Promise(resolve => {
+        if (document.querySelector(selector)) {
+            return resolve(document.querySelector(selector));
+        }
+
+        const observer = new MutationObserver(mutations => {
+            if (document.querySelector(selector)) {
+                observer.disconnect();
+                resolve(document.querySelector(selector));
+            }
+        });
+
+        // If you get "parameter 1 is not of type 'Node'" error, see https://stackoverflow.com/a/77855838/492336
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+    });
+}
+
+function redoPrimaryTagSelection(){
+    const select = document.getElementById("id_primary_tag_slug"); 
+    let selected = Array.from(select.children).filter((child) => child.hasAttribute("selected")).map((child) => child.value);
+    select.innerHTML = "";
+    
+    if (selected.length > 0) {
+        selected = selected[0];
+    }
+
+    for (option of primaryTagOptions) {
+        const elem = document.createElement("option");
+        elem.value = option[0];
+        elem.innerText = option[1];
+        if (selected === option[0]) {
+            elem.setAttribute("selected", "");
+        }
+        select.appendChild(elem);
+    }
+}
+
+waitForElm('#id_tags').then((elem) => {
+    waitForElm('#id_primary_tag_slug').then((elem) => {
+        setTimeout(() => {
+            const primaryTags = Array.from($('#id_tags').tagit("instance").tagList.children()).map((tag) => tag.children[0].innerText.replaceAll('"', ""));
+            console.log(primaryTags);
+            console.log(Array.from(elem.children).map((child) => [child.value, child.innerText]));
+            primaryTagOptions = Array.from(elem.children).filter((child) => primaryTags.includes(child.innerText)).map((child) => [child.value, child.innerText]);
+            
+            for (tag of primaryTags) {
+                if (primaryTagOptions.filter((t) => t.includes(tag)).length == 0) {
+                    primaryTagOptions.push([tag, tag]);
+                }
+            }
+            
+            console.log(primaryTagOptions);
+            redoPrimaryTagSelection();
+        }, 100);
+
+    });
+
+    $('#id_tags').tagit({"afterTagRemoved": function(event, tag) { 
+        primaryTagOptions = primaryTagOptions.filter((t) => !t.includes(tag.tagLabel));
+        redoPrimaryTagSelection();
+    }});
+
+    $('#id_tags').tagit({"afterTagAdded": function(event,tag) {
+        if (primaryTagOptions.filter((t) => t.includes(tag.tagLabel)).length == 0) {
+            primaryTagOptions.push([tag.tagLabel, tag.tagLabel]);
+            redoPrimaryTagSelection()
+        }
+    }});
+});

--- a/ubyssey/static_src/webpack.common.js
+++ b/ubyssey/static_src/webpack.common.js
@@ -32,6 +32,7 @@ module.exports = {
 
     'queer-substance-abuse': './src/js/queer-substance-abuse.js',
     'nocturne-window-watching': './src/js/nocturne-window-watching.js',
+    'widgets/tags-panel': './src/js/widgets/tags-panel.js',
   },
   output: {
     path: path.join(__dirname, '..', 'static/ubyssey/js'),


### PR DESCRIPTION
Made primary tags as a dropdown

It is initialized with every tag ever as an option. (**This is very bad and annoying and I hate it.**  But I can't figure out how to pass page specific information into the widget. Ideally it is initialized with the choices as only the tags in the tags field)

then after rendering it removes everything that isn't in the tags field with javascript

used callbacks provided by https://github.com/wagtail/wagtail/blob/main/wagtail/admin/static_src/wagtailadmin/js/vendor/tag-it.js to add new tags to the primary tags field dropdown as they are added. Also removed from dropdown as they are removed.