### PR TITLE
Auto updated suggested bar setting when categories are selected or removed

### DIFF
--- a/article/models.py
+++ b/article/models.py
@@ -420,6 +420,19 @@ class TagsFieldPanel(FieldPanel):
         class Media:
             js = ["ubyssey/js/widgets/tags-panel.js"]    
 
+class SuggestedBarFieldPanel(FieldPanel):
+    '''
+    Adds the javascript that auto-updates the choice of suggested bar when editors select a category.
+    Generally we want the suggested bar to use the category if there is one and the primary tag if there isn't.
+    But there might be exceptions so we want editors to have control. But editors can't be trusted to actually
+    to use this control reliably. They usually just use the default settings on everything.
+    So we auto update this field which technically offers editors control but does whats generally correct as defualt otherwise.
+    '''
+    class BoundPanel(FieldPanel.BoundPanel):
+        class Media:
+            js = ["ubyssey/js/widgets/auto-update-suggested-bar-choice.js"]    
+
+
 class PrimaryTagSelect(Select):
     '''
     Bizzare roundabout way to add the value of the field as one of the choices.
@@ -557,7 +570,7 @@ class ArticlePage(RoutablePageMixin, SectionablePage, UbysseyMenuMixin):
         blank=True,
         default='',
         max_length=255,
-        help_text="IF USED, SHOULD ALSO BE IN TAGS FIELD. Enter the slug of the tag to be used for linking at the end of the article. For example, the slug of the tag 'blue chip' is 'blue-chip'.",
+        help_text="The primary tag can be used for listing articles in the suggested bar at the end. It is also used to gather related articles to be presented on some section pages.",
     )
     tag_page_link = models.BooleanField(
         null=False,
@@ -569,9 +582,9 @@ class ArticlePage(RoutablePageMixin, SectionablePage, UbysseyMenuMixin):
     filter_by_tags = models.BooleanField(
         null=False,
         blank=False,
-        default=False,
-        help_text="CHECK THIS to fill the suggested bar with other articles in this section that are also tagged with the primary tag.",
-        verbose_name="Use Primary Tag for Suggested Bar"
+        default=True,
+        help_text="This determines what articles will be listed in the suggested bar at the end of the article.",
+        verbose_name="Suggested Bar"
     )
 
     disclaimer = RichTextField(
@@ -810,7 +823,13 @@ class ArticlePage(RoutablePageMixin, SectionablePage, UbysseyMenuMixin):
                     widget=PrimaryTagSelect(),
                 ),
                 FieldPanel("tag_page_link"),
-                FieldPanel("filter_by_tags"),
+                SuggestedBarFieldPanel(
+                    "filter_by_tags",
+                    widget=Select(choices=[
+                        (False, "Section"),
+                        (True, "Primary tag")
+                    ])
+                )
             ],
             heading="Categories and Tags",
             classname="collapsible",

--- a/ubyssey/static_src/src/js/widgets/auto-update-suggested-bar-choice.js
+++ b/ubyssey/static_src/src/js/widgets/auto-update-suggested-bar-choice.js
@@ -1,0 +1,64 @@
+function waitForElm(selector) {
+    // Source: https://stackoverflow.com/a/61511955
+    return new Promise(resolve => {
+        if (document.querySelector(selector)) {
+            return resolve(document.querySelector(selector));
+        }
+
+        const observer = new MutationObserver(mutations => {
+            if (document.querySelector(selector)) {
+                observer.disconnect();
+                resolve(document.querySelector(selector));
+            }
+        });
+
+        // If you get "parameter 1 is not of type 'Node'" error, see https://stackoverflow.com/a/77855838/492336
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+    });
+}
+
+function setSuggestBarOptionNames(options, categoryBlank) {
+    for (let option of options) {
+        if (option.value==="False") {
+            if (categoryBlank) {
+                option.innerText = "Section";
+            } else {
+                option.innerText = "Category";
+            }
+        }
+    }
+}
+
+const updateSuggestedChoice = (mutationList, observer) => {
+    const suggestedBarInput = document.getElementById("id_filter_by_tags");
+    const options = Array.from(suggestedBarInput.children);
+    const categoryBlank = mutationList[0].target.classList.contains("blank");
+
+    setSuggestBarOptionNames(options, categoryBlank);
+
+    for (let option of options) {
+        option.selected = (option.value=="True" === categoryBlank);
+        
+        if (option.selected) {
+            option.setAttribute("selected", "");
+        } else {
+            option.removeAttribute("selected");
+        }
+    }
+};
+
+const observer = new MutationObserver(updateSuggestedChoice); 
+
+waitForElm("#id_category_page-chooser").then((targetNode) => {
+
+    waitForElm("#id_filter_by_tags").then((suggestedBarInput) => {
+        const options = Array.from(suggestedBarInput.children);
+        const categoryBlank = targetNode.classList.contains("blank")
+        setSuggestBarOptionNames(options, categoryBlank);
+    })
+
+    observer.observe(targetNode, {attributes: true});
+});

--- a/ubyssey/static_src/src/js/widgets/tags-panel.js
+++ b/ubyssey/static_src/src/js/widgets/tags-panel.js
@@ -34,15 +34,16 @@ function redoPrimaryTagSelection(){
         selected = selected[0];
     }
 
-    for (option of primaryTagOptions) {
+    primaryTagOptions.forEach((option, index) => {
         const elem = document.createElement("option");
         elem.value = option[0];
         elem.innerText = option[1];
-        if (selected === option[0]) {
+        if (selected === option[0] || selected.length===0 && index===0) {
+            elem.selected = true;
             elem.setAttribute("selected", "");
         }
         select.appendChild(elem);
-    }
+    });
 }
 
 waitForElm('#id_tags').then((elem) => {
@@ -75,7 +76,7 @@ waitForElm('#id_tags').then((elem) => {
             // When a tag is added, add it to the dropdown
             $('#id_tags').tagit({"afterTagAdded": function(event,tag) {
                 if (primaryTagOptions.filter((t) => t.includes(tag.tagLabel)).length == 0) {
-                    primaryTagOptions.push([tag.tagLabel, tag.tagLabel]);
+                    primaryTagOptions.push([tag.tagLabel.replaceAll('"', ""), tag.tagLabel.replaceAll('"', "")]);
                     redoPrimaryTagSelection()
                 }
             }});

--- a/ubyssey/static_src/webpack.common.js
+++ b/ubyssey/static_src/webpack.common.js
@@ -33,6 +33,7 @@ module.exports = {
     'queer-substance-abuse': './src/js/queer-substance-abuse.js',
     'nocturne-window-watching': './src/js/nocturne-window-watching.js',
     'widgets/tags-panel': './src/js/widgets/tags-panel.js',
+    'widgets/auto-update-suggested-bar-choice': './src/js/widgets/auto-update-suggested-bar-choice.js',
   },
   output: {
     path: path.join(__dirname, '..', 'static/ubyssey/js'),


### PR DESCRIPTION
People deviate around the default settings. Thats why when when doing UI design the default setting should mostly be what you want the users to do. The easiest thing to do should also be the correct thing to do. What I want editors to do for the suggested bar is to almost always use the primary tag but not use it when they select a category. The existence of that conditional made it difficult to guide editor behaviour with defaults. I defaulted to not selecting the primary tag because I saw it as more important to use the category when one was selected. Consequently, almost no articles used the primary tag. 

This PR solves this issue by automatically updating the suggested bar choice when a category is chosen or removed. Uses some javascript but I think its actually not too gross?