### PR TITLE
Automate deploying vm

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,13 +1,10 @@
 name: Deploy to staging
 
-# on:
-#   release:
-#     types: [published]
-
 on:
-  push:
-    branches:
-      - automate-deploying-vm
+  schedule:
+    # Run every Sunday at 2:00 AM UTC
+    - cron: '0 2 * * 0'
+  workflow_dispatch: # Allow manual triggering
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -7,7 +7,7 @@ name: Deploy to staging
 on:
   push:
     branches:
-      - staging-deploy
+      - automate-deploying-vm
 
 jobs:
   deploy:
@@ -80,7 +80,7 @@ jobs:
         run: scp docker-compose.yml staging:/opt/ubyssey.ca/docker-compose.yml
 
       - name: Upload nginx configuration
-        run: scp nginx.conf staging:/opt/ubyssey.ca/nginx/nginx.conf
+        run: scp nginx-staging.conf staging:/opt/ubyssey.ca/nginx/nginx.conf
 
       - name: Sync secrets from Google Cloud Platform
         run: cat sync-secrets.sh | ssh staging

--- a/.github/workflows/deploy_vm.yml
+++ b/.github/workflows/deploy_vm.yml
@@ -43,9 +43,9 @@ jobs:
         id: auth
         uses: 'google-github-actions/auth@v2'
         with:
-          workload_identity_provider: 'projects/1012602718138/locations/global/workloadIdentityPools/ubyssey-wif-pool-staging/providers/ubyssey-oidc-github-staging'          # Replace with your PRODUCTION Service Account for 'ubyssey-prd'
-          service_account: 'deployment@ubyssey-staging.iam.gserviceaccount.com'
-          
+          workload_identity_provider: 'projects/863738545301/locations/global/workloadIdentityPools/ubyssey-wif-pool-prd/providers/ubyssey-oidc-github-prd'
+          service_account: 'deployment@ubyssey-prd.iam.gserviceaccount.com'
+                    
       - name: Determine Action
         id: get_action
         run: |

--- a/.github/workflows/deploy_vm.yml
+++ b/.github/workflows/deploy_vm.yml
@@ -56,11 +56,11 @@ jobs:
         id: init
         run: terraform init
 
-      - name: Terraform Plan
-        id: plan
-        if: steps.get_action.outputs.action == 'deploy'
-        run: terraform plan -out=tfplan -input=false
-        continue-on-error: false 
+      # - name: Terraform Plan
+      #   id: plan
+      #   if: steps.get_action.outputs.action == 'deploy'
+      #   run: terraform plan -out=tfplan -input=false
+      #   continue-on-error: false 
 
       - name: Terraform Apply
         if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'

--- a/.github/workflows/deploy_vm.yml
+++ b/.github/workflows/deploy_vm.yml
@@ -9,7 +9,7 @@ on:
       action:
         description: 'Terraform action to perform (deploy or destroy)'
         required: true
-        default: 'destroy'
+        default: 'deploy'
         type: choice
         options:
           - deploy
@@ -46,7 +46,7 @@ jobs:
       - name: Determine Action
         id: get_action
         run: |
-          ACTION="destroy" # Default for push events
+          ACTION="deploy" # Default for push events
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             ACTION="${{ github.event.inputs.action }}"
           fi
@@ -56,15 +56,15 @@ jobs:
         id: init
         run: terraform init
 
-      # - name: Terraform Plan
-      #   id: plan
-      #   if: steps.get_action.outputs.action == 'deploy'
-      #   run: terraform plan -out=tfplan -input=false
-      #   continue-on-error: false 
+      - name: Terraform Plan
+        id: plan
+        if: steps.get_action.outputs.action == 'deploy'
+        run: terraform plan -out=tfplan -input=false
+        continue-on-error: false 
 
-      # - name: Terraform Apply
-      #   if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
-      #   run: terraform apply -auto-approve -input=false tfplan
+      - name: Terraform Apply
+        if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
+        run: terraform apply -auto-approve -input=false tfplan
 
       - name: Terraform Destroy
         if: steps.get_action.outputs.action == 'destroy'

--- a/.github/workflows/deploy_vm.yml
+++ b/.github/workflows/deploy_vm.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   terraform:
-    name: 'Terraform ${{ github.event.inputs.action || ''deploy'' }}' 
+    name: 'Terraform ${{ github.event.inputs.action }}' 
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/deploy_vm.yml
+++ b/.github/workflows/deploy_vm.yml
@@ -37,19 +37,16 @@ jobs:
         with:
           terraform_version: "1.11.3"
 
-      # Authenticate to Google Cloud using Workload Identity Federation
-      # TODO: IMPORTANT - Update with your PRODUCTION WIF provider and Service Account for 'ubyssey-prd'
-      - name: Authenticate to Google Cloud
-        id: auth
+      - name: Authenticate with Google Cloud Platform
         uses: 'google-github-actions/auth@v2'
         with:
-          workload_identity_provider: 'projects/863738545301/locations/global/workloadIdentityPools/ubyssey-wif-pool-prd/providers/ubyssey-oidc-github-prd'
-          service_account: 'deployment@ubyssey-prd.iam.gserviceaccount.com'
+          workload_identity_provider: 'projects/1012602718138/locations/global/workloadIdentityPools/ubyssey-wif-pool-staging/providers/ubyssey-oidc-github-staging'
+          service_account: 'deployment@ubyssey-staging.iam.gserviceaccount.com'
                     
       - name: Determine Action
         id: get_action
         run: |
-          ACTION="destroy" # Default for push events
+          ACTION="deploy" # Default for push events
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             ACTION="${{ github.event.inputs.action }}"
           fi
@@ -63,7 +60,7 @@ jobs:
         id: plan
         if: steps.get_action.outputs.action == 'deploy'
         run: terraform plan -out=tfplan -input=false
-        continue-on-error: false # Optional: set to true if you want to see plan even if it fails
+        continue-on-error: false 
 
       - name: Terraform Apply
         if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'

--- a/.github/workflows/deploy_vm.yml
+++ b/.github/workflows/deploy_vm.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Determine Action
         id: get_action
         run: |
-          ACTION="deploy" # Default for push events
+          ACTION="destroy" # Default for push events
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             ACTION="${{ github.event.inputs.action }}"
           fi
@@ -62,9 +62,9 @@ jobs:
       #   run: terraform plan -out=tfplan -input=false
       #   continue-on-error: false 
 
-      - name: Terraform Apply
-        if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
-        run: terraform apply -auto-approve -input=false tfplan
+      # - name: Terraform Apply
+      #   if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
+      #   run: terraform apply -auto-approve -input=false tfplan
 
       - name: Terraform Destroy
         if: steps.get_action.outputs.action == 'destroy'

--- a/.github/workflows/deploy_vm.yml
+++ b/.github/workflows/deploy_vm.yml
@@ -56,15 +56,15 @@ jobs:
         id: init
         run: terraform init
 
-      - name: Terraform Plan
-        id: plan
-        if: steps.get_action.outputs.action == 'deploy'
-        run: terraform plan -out=tfplan -input=false
-        continue-on-error: false 
+      # - name: Terraform Plan
+      #   id: plan
+      #   if: steps.get_action.outputs.action == 'deploy'
+      #   run: terraform plan -out=tfplan -input=false
+      #   continue-on-error: false 
 
-      - name: Terraform Apply
-        if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
-        run: terraform apply -auto-approve -input=false tfplan
+      # - name: Terraform Apply
+      #   if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
+      #   run: terraform apply -auto-approve -input=false tfplan
 
       - name: Terraform Destroy
         if: steps.get_action.outputs.action == 'destroy'

--- a/.github/workflows/deploy_vm.yml
+++ b/.github/workflows/deploy_vm.yml
@@ -1,0 +1,74 @@
+name: Terraform GCP VM Deployment
+
+on:
+  push:
+    branches:
+      - automate-deploying-vm 
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Terraform action to perform (deploy or destroy)'
+        required: true
+        default: 'deploy'
+        type: choice
+        options:
+          - deploy
+          - destroy
+
+permissions:
+  contents: 'read'
+  id-token: 'write'
+
+jobs:
+  terraform:
+    name: 'Terraform ${{ github.event.inputs.action || ''deploy'' }}' 
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./deploy-vm
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.11.3"
+
+      # Authenticate to Google Cloud using Workload Identity Federation
+      # TODO: IMPORTANT - Update with your PRODUCTION WIF provider and Service Account for 'ubyssey-prd'
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: 'projects/1012602718138/locations/global/workloadIdentityPools/ubyssey-wif-pool-staging/providers/ubyssey-oidc-github-staging'          # Replace with your PRODUCTION Service Account for 'ubyssey-prd'
+          service_account: 'deployment@ubyssey-staging.iam.gserviceaccount.com'
+          
+      - name: Determine Action
+        id: get_action
+        run: |
+          ACTION="deploy" # Default for push events
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            ACTION="${{ github.event.inputs.action }}"
+          fi
+          echo "action=$ACTION" >> $GITHUB_OUTPUT
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Plan
+        id: plan
+        if: steps.get_action.outputs.action == 'deploy'
+        run: terraform plan -out=tfplan -input=false
+        continue-on-error: false # Optional: set to true if you want to see plan even if it fails
+
+      - name: Terraform Apply
+        if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
+        run: terraform apply -auto-approve -input=false tfplan
+
+      - name: Terraform Destroy
+        if: steps.get_action.outputs.action == 'destroy'
+        run: terraform destroy -auto-approve -input=false

--- a/.github/workflows/deploy_vm.yml
+++ b/.github/workflows/deploy_vm.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Determine Action
         id: get_action
         run: |
-          ACTION="deploy" # Default for push events
+          ACTION="destroy" # Default for push events
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             ACTION="${{ github.event.inputs.action }}"
           fi

--- a/.github/workflows/deploy_vm.yml
+++ b/.github/workflows/deploy_vm.yml
@@ -9,7 +9,7 @@ on:
       action:
         description: 'Terraform action to perform (deploy or destroy)'
         required: true
-        default: 'deploy'
+        default: 'destroy'
         type: choice
         options:
           - deploy

--- a/.github/workflows/deploy_vm.yml
+++ b/.github/workflows/deploy_vm.yml
@@ -49,11 +49,8 @@ jobs:
       - name: Determine Action
         id: get_action
         run: |
-          ACTION="deploy" # Default for push events
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             ACTION="${{ github.event.inputs.action }}"
-          fi
-          echo "action=$ACTION" >> $GITHUB_OUTPUT
+            echo "action=$ACTION" >> $GITHUB_OUTPUT
 
       - name: Terraform Init
         id: init

--- a/.github/workflows/deploy_vm.yml
+++ b/.github/workflows/deploy_vm.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   terraform:
-    name: 'Terraform ${{ github.event.inputs.action }}' 
+    name: 'Terraform ${{ github.event.inputs.action || ''deploy'' }}' 
     runs-on: ubuntu-latest
 
     defaults:
@@ -49,8 +49,11 @@ jobs:
       - name: Determine Action
         id: get_action
         run: |
+          ACTION="destroy" # Default for push events
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             ACTION="${{ github.event.inputs.action }}"
-            echo "action=$ACTION" >> $GITHUB_OUTPUT
+          fi
+          echo "action=$ACTION" >> $GITHUB_OUTPUT
 
       - name: Terraform Init
         id: init

--- a/.github/workflows/deploy_vm_production.yml
+++ b/.github/workflows/deploy_vm_production.yml
@@ -11,6 +11,58 @@ on:
         options:
           - deploy
           - destroy
+      project_provider:
+        description: 'GCP Project ID for the provider (e.g., ubyssey-staging). Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      project_snapshot:
+        description: 'GCP Project ID for snapshots. Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      region:
+        description: 'GCP Region (e.g., us-west1). Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      zone:
+        description: 'GCP Zone (e.g., us-west1-a). Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      vm_name:
+        description: 'Name for the VM (e.g., ubyssey-staging-vm). Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      machine_type:
+        description: 'Machine type for the VM (e.g., e2-medium). Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      disk_size_gb:
+        description: 'It is an integer. Boot disk size in GB. Default from variables.tf will be used if empty.'
+        required: false
+        type: string 
+      disk_type:
+        description: 'Boot disk type (e.g., pd-standard). Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      snapshot_filter:
+        description: 'Filter for selecting the snapshot. Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      service_account_email:
+        description: 'Service account email for the VM. Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      boot_disk_from_snapshot:
+        description: 'Name for the boot disk created from snapshot. Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      boot_disk_image:
+        description: 'Boot disk image to use (overrides snapshot). Default from variables.tf will be used if empty (null).'
+        required: false
+        type: string
+      snapshot_retention_days:
+        description: 'It is an integer. Number of days to retain snapshots. Default from variables.tf will be used if empty.'
+        required: false
+        type: string
 
 permissions:
   contents: 'read'
@@ -37,8 +89,8 @@ jobs:
       - name: Authenticate with Google Cloud Platform
         uses: 'google-github-actions/auth@v2'
         with:
-          workload_identity_provider: 'projects/1012602718138/locations/global/workloadIdentityPools/ubyssey-wif-pool-staging/providers/ubyssey-oidc-github-staging'
-          service_account: 'deployment@ubyssey-staging.iam.gserviceaccount.com'
+          workload_identity_provider: 'projects/863738545301/locations/global/workloadIdentityPools/ubyssey-wif-pool-prd/providers/ubyssey-oidc-github-prd'
+          service_account: 'deployment@ubyssey-prd.iam.gserviceaccount.com'
                     
       - name: Determine Action
         id: get_action
@@ -56,13 +108,55 @@ jobs:
       - name: Terraform Plan
         id: plan
         if: steps.get_action.outputs.action == 'deploy'
+        env:
+          TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
+          TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
+          TF_VAR_region: ${{ github.event.inputs.region }}
+          TF_VAR_zone: ${{ github.event.inputs.zone }}
+          TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
+          TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
+          TF_VAR_disk_size_gb: ${{ github.event.inputs.disk_size_gb }}
+          TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
+          TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
+          TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
+          TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
+          TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
+          TF_VAR_snapshot_retention_days: ${{ github.event.inputs.snapshot_retention_days }}
         run: terraform plan -out=tfplan -input=false
-        continue-on-error: false 
+        continue-on-error: false
 
       - name: Terraform Apply
         if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
+        env:
+          TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
+          TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
+          TF_VAR_region: ${{ github.event.inputs.region }}
+          TF_VAR_zone: ${{ github.event.inputs.zone }}
+          TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
+          TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
+          TF_VAR_disk_size_gb: ${{ github.event.inputs.disk_size_gb }}
+          TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
+          TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
+          TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
+          TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
+          TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
+          TF_VAR_snapshot_retention_days: ${{ github.event.inputs.snapshot_retention_days }}
         run: terraform apply -auto-approve -input=false tfplan
 
       - name: Terraform Destroy
         if: steps.get_action.outputs.action == 'destroy'
+        env:
+          TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
+          TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
+          TF_VAR_region: ${{ github.event.inputs.region }}
+          TF_VAR_zone: ${{ github.event.inputs.zone }}
+          TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
+          TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
+          TF_VAR_disk_size_gb: ${{ github.event.inputs.disk_size_gb }}
+          TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
+          TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
+          TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
+          TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
+          TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
+          TF_VAR_snapshot_retention_days: ${{ github.event.inputs.snapshot_retention_days }}
         run: terraform destroy -auto-approve -input=false

--- a/.github/workflows/deploy_vm_production.yml
+++ b/.github/workflows/deploy_vm_production.yml
@@ -1,6 +1,9 @@
 name: Terraform GCP VM Deployment
 
 on:
+  push:
+    branches:
+      - automate-deploying-vm
   workflow_dispatch:
     inputs:
       action:
@@ -11,42 +14,6 @@ on:
         options:
           - deploy
           - destroy
-      project_provider:
-        description: 'GCP Project ID for the provider (e.g., ubyssey-staging). Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      project_snapshot:
-        description: 'GCP Project ID for snapshots. Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      vm_name:
-        description: 'Name for the VM (e.g., ubyssey-staging-vm). Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      machine_type:
-        description: 'Machine type for the VM (e.g., e2-medium). Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      disk_type:
-        description: 'Boot disk type (e.g., pd-standard). Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      snapshot_filter:
-        description: 'Filter for selecting the snapshot. Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      service_account_email:
-        description: 'Service account email for the VM. Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      boot_disk_from_snapshot:
-        description: 'Name for the boot disk created from snapshot. Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      boot_disk_image:
-        description: 'Boot disk image to use (overrides snapshot). Default from variables.tf will be used if empty (null).'
-        required: false
-        type: string
 
 permissions:
   contents: 'read'
@@ -93,42 +60,36 @@ jobs:
         id: plan
         if: steps.get_action.outputs.action == 'deploy'
         env:
-          TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
-          TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
-          TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
-          TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
-          TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
-          TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
-          TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
-          TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
-          TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
+          TF_VAR_project_provider: "ubyssey-prd"
+          TF_VAR_project_snapshot: "ubyssey-prd-snapshot"
+          TF_VAR_vm_name: "ubyssey-prd-vm-2"
+          TF_VAR_machine_type: "e2-highcpu-8"
+          TF_VAR_snapshot_filter: "ubyssey-prd-vm"
+          TF_VAR_service_account_email: "863738545301-compute@developer.gserviceaccount.com"
+          TF_VAR_boot_disk_from_snapshot: "ubyssey-prd-vm-2-boot-disk"
         run: terraform plan -out=tfplan -input=false
         continue-on-error: false
 
       - name: Terraform Apply
         if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
         env:
-          TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
-          TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
-          TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
-          TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
-          TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
-          TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
-          TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
-          TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
-          TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
+          TF_VAR_project_provider: "ubyssey-prd"
+          TF_VAR_project_snapshot: "ubyssey-prd-snapshot"
+          TF_VAR_vm_name: "ubyssey-prd-vm-2"
+          TF_VAR_machine_type: "e2-highcpu-8"
+          TF_VAR_snapshot_filter: "ubyssey-prd-vm"
+          TF_VAR_service_account_email: "863738545301-compute@developer.gserviceaccount.com"
+          TF_VAR_boot_disk_from_snapshot: "ubyssey-prd-vm-2-boot-disk"
         run: terraform apply -auto-approve -input=false tfplan
 
       - name: Terraform Destroy
         if: steps.get_action.outputs.action == 'destroy'
         env:
-          TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
-          TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
-          TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
-          TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
-          TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
-          TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
-          TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
-          TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
-          TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
+          TF_VAR_project_provider: "ubyssey-prd"
+          TF_VAR_project_snapshot: "ubyssey-prd-snapshot"
+          TF_VAR_vm_name: "ubyssey-prd-vm-2"
+          TF_VAR_machine_type: "e2-highcpu-8"
+          TF_VAR_snapshot_filter: "ubyssey-prd-vm"
+          TF_VAR_service_account_email: "863738545301-compute@developer.gserviceaccount.com"
+          TF_VAR_boot_disk_from_snapshot: "ubyssey-prd-vm-2-boot-disk"
         run: terraform destroy -auto-approve -input=false

--- a/.github/workflows/deploy_vm_production.yml
+++ b/.github/workflows/deploy_vm_production.yml
@@ -9,7 +9,7 @@ on:
       action:
         description: 'Terraform action to perform (deploy or destroy)'
         required: true
-        default: 'deploy'
+        default: 'destroy'
         type: choice
         options:
           - deploy
@@ -46,7 +46,7 @@ jobs:
       - name: Determine Action
         id: get_action
         run: |
-          ACTION="deploy" # Default for push events
+          ACTION="destroy" # Default for push events
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             ACTION="${{ github.event.inputs.action }}"
           fi

--- a/.github/workflows/deploy_vm_production.yml
+++ b/.github/workflows/deploy_vm_production.yml
@@ -61,7 +61,7 @@ jobs:
         if: steps.get_action.outputs.action == 'deploy'
         env:
           TF_VAR_project_provider: "ubyssey-prd"
-          TF_VAR_project_snapshot: "ubyssey-prd-snapshot"
+          TF_VAR_project_snapshot: "ubyssey-prd"
           TF_VAR_vm_name: "ubyssey-prd-vm-2"
           TF_VAR_machine_type: "e2-highcpu-8"
           TF_VAR_snapshot_filter: "ubyssey-prd-vm"
@@ -74,7 +74,7 @@ jobs:
         if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
         env:
           TF_VAR_project_provider: "ubyssey-prd"
-          TF_VAR_project_snapshot: "ubyssey-prd-snapshot"
+          TF_VAR_project_snapshot: "ubyssey-prd"
           TF_VAR_vm_name: "ubyssey-prd-vm-2"
           TF_VAR_machine_type: "e2-highcpu-8"
           TF_VAR_snapshot_filter: "ubyssey-prd-vm"
@@ -86,7 +86,7 @@ jobs:
         if: steps.get_action.outputs.action == 'destroy'
         env:
           TF_VAR_project_provider: "ubyssey-prd"
-          TF_VAR_project_snapshot: "ubyssey-prd-snapshot"
+          TF_VAR_project_snapshot: "ubyssey-prd"
           TF_VAR_vm_name: "ubyssey-prd-vm-2"
           TF_VAR_machine_type: "e2-highcpu-8"
           TF_VAR_snapshot_filter: "ubyssey-prd-vm"

--- a/.github/workflows/deploy_vm_production.yml
+++ b/.github/workflows/deploy_vm_production.yml
@@ -1,15 +1,12 @@
 name: Terraform GCP VM Deployment
 
 on:
-  push:
-    branches:
-      - automate-deploying-vm 
   workflow_dispatch:
     inputs:
       action:
         description: 'Terraform action to perform (deploy or destroy)'
         required: true
-        default: 'destroy'
+        default: 'deploy'
         type: choice
         options:
           - deploy
@@ -46,7 +43,7 @@ jobs:
       - name: Determine Action
         id: get_action
         run: |
-          ACTION="destroy" # Default for push events
+          ACTION="deploy" # Default for push events
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             ACTION="${{ github.event.inputs.action }}"
           fi
@@ -56,15 +53,15 @@ jobs:
         id: init
         run: terraform init
 
-      # - name: Terraform Plan
-      #   id: plan
-      #   if: steps.get_action.outputs.action == 'deploy'
-      #   run: terraform plan -out=tfplan -input=false
-      #   continue-on-error: false 
+      - name: Terraform Plan
+        id: plan
+        if: steps.get_action.outputs.action == 'deploy'
+        run: terraform plan -out=tfplan -input=false
+        continue-on-error: false 
 
-      # - name: Terraform Apply
-      #   if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
-      #   run: terraform apply -auto-approve -input=false tfplan
+      - name: Terraform Apply
+        if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
+        run: terraform apply -auto-approve -input=false tfplan
 
       - name: Terraform Destroy
         if: steps.get_action.outputs.action == 'destroy'

--- a/.github/workflows/deploy_vm_production.yml
+++ b/.github/workflows/deploy_vm_production.yml
@@ -64,7 +64,7 @@ jobs:
           TF_VAR_project_snapshot: "ubyssey-prd"
           TF_VAR_vm_name: "ubyssey-prd-vm-2"
           TF_VAR_machine_type: "e2-highcpu-8"
-          TF_VAR_snapshot_filter: "ubyssey-prd-vm"
+          TF_VAR_snapshot_filter: "name eq ^ubyssey-prd-vm.*"
           TF_VAR_service_account_email: "863738545301-compute@developer.gserviceaccount.com"
           TF_VAR_boot_disk_from_snapshot: "ubyssey-prd-vm-2-boot-disk"
         run: terraform plan -out=tfplan -input=false
@@ -77,7 +77,7 @@ jobs:
           TF_VAR_project_snapshot: "ubyssey-prd"
           TF_VAR_vm_name: "ubyssey-prd-vm-2"
           TF_VAR_machine_type: "e2-highcpu-8"
-          TF_VAR_snapshot_filter: "ubyssey-prd-vm"
+          TF_VAR_snapshot_filter: "name eq ^ubyssey-prd-vm.*"
           TF_VAR_service_account_email: "863738545301-compute@developer.gserviceaccount.com"
           TF_VAR_boot_disk_from_snapshot: "ubyssey-prd-vm-2-boot-disk"
         run: terraform apply -auto-approve -input=false tfplan
@@ -89,7 +89,7 @@ jobs:
           TF_VAR_project_snapshot: "ubyssey-prd"
           TF_VAR_vm_name: "ubyssey-prd-vm-2"
           TF_VAR_machine_type: "e2-highcpu-8"
-          TF_VAR_snapshot_filter: "ubyssey-prd-vm"
+          TF_VAR_snapshot_filter: "name eq ^ubyssey-prd-vm.*"
           TF_VAR_service_account_email: "863738545301-compute@developer.gserviceaccount.com"
           TF_VAR_boot_disk_from_snapshot: "ubyssey-prd-vm-2-boot-disk"
         run: terraform destroy -auto-approve -input=false

--- a/.github/workflows/deploy_vm_production.yml
+++ b/.github/workflows/deploy_vm_production.yml
@@ -1,15 +1,12 @@
 name: Terraform GCP VM Deployment
 
 on:
-  push:
-    branches:
-      - automate-deploying-vm
   workflow_dispatch:
     inputs:
       action:
         description: 'Terraform action to perform (deploy or destroy)'
         required: true
-        default: 'destroy'
+        default: 'deploy'
         type: choice
         options:
           - deploy
@@ -46,7 +43,7 @@ jobs:
       - name: Determine Action
         id: get_action
         run: |
-          ACTION="destroy" # Default for push events
+          ACTION="deploy" 
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             ACTION="${{ github.event.inputs.action }}"
           fi

--- a/.github/workflows/deploy_vm_production.yml
+++ b/.github/workflows/deploy_vm_production.yml
@@ -54,13 +54,12 @@ jobs:
 
       - name: Terraform Init
         id: init
-        run: terraform init
+        run: terraform init -backend-config=backend-production.conf
 
       - name: Terraform Plan
         id: plan
         if: steps.get_action.outputs.action == 'deploy'
         env:
-          TF_VAR_gcs_bucket: "ubyssey-terraform-state-bucket-prd"
           TF_VAR_project_provider: "ubyssey-prd"
           TF_VAR_project_snapshot: "ubyssey-prd-snapshot"
           TF_VAR_vm_name: "ubyssey-prd-vm-2"
@@ -74,7 +73,6 @@ jobs:
       - name: Terraform Apply
         if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
         env:
-          TF_VAR_gcs_bucket: "ubyssey-terraform-state-bucket-prd"
           TF_VAR_project_provider: "ubyssey-prd"
           TF_VAR_project_snapshot: "ubyssey-prd-snapshot"
           TF_VAR_vm_name: "ubyssey-prd-vm-2"
@@ -87,7 +85,6 @@ jobs:
       - name: Terraform Destroy
         if: steps.get_action.outputs.action == 'destroy'
         env:
-          TF_VAR_gcs_bucket: "ubyssey-terraform-state-bucket-prd"
           TF_VAR_project_provider: "ubyssey-prd"
           TF_VAR_project_snapshot: "ubyssey-prd-snapshot"
           TF_VAR_vm_name: "ubyssey-prd-vm-2"

--- a/.github/workflows/deploy_vm_production.yml
+++ b/.github/workflows/deploy_vm_production.yml
@@ -60,6 +60,7 @@ jobs:
         id: plan
         if: steps.get_action.outputs.action == 'deploy'
         env:
+          TF_VAR_gcs_bucket: "ubyssey-terraform-state-bucket-prd"
           TF_VAR_project_provider: "ubyssey-prd"
           TF_VAR_project_snapshot: "ubyssey-prd-snapshot"
           TF_VAR_vm_name: "ubyssey-prd-vm-2"
@@ -73,6 +74,7 @@ jobs:
       - name: Terraform Apply
         if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
         env:
+          TF_VAR_gcs_bucket: "ubyssey-terraform-state-bucket-prd"
           TF_VAR_project_provider: "ubyssey-prd"
           TF_VAR_project_snapshot: "ubyssey-prd-snapshot"
           TF_VAR_vm_name: "ubyssey-prd-vm-2"
@@ -85,6 +87,7 @@ jobs:
       - name: Terraform Destroy
         if: steps.get_action.outputs.action == 'destroy'
         env:
+          TF_VAR_gcs_bucket: "ubyssey-terraform-state-bucket-prd"
           TF_VAR_project_provider: "ubyssey-prd"
           TF_VAR_project_snapshot: "ubyssey-prd-snapshot"
           TF_VAR_vm_name: "ubyssey-prd-vm-2"

--- a/.github/workflows/deploy_vm_production.yml
+++ b/.github/workflows/deploy_vm_production.yml
@@ -19,14 +19,6 @@ on:
         description: 'GCP Project ID for snapshots. Default from variables.tf will be used if empty.'
         required: false
         type: string
-      region:
-        description: 'GCP Region (e.g., us-west1). Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      zone:
-        description: 'GCP Zone (e.g., us-west1-a). Default from variables.tf will be used if empty.'
-        required: false
-        type: string
       vm_name:
         description: 'Name for the VM (e.g., ubyssey-staging-vm). Default from variables.tf will be used if empty.'
         required: false
@@ -35,10 +27,6 @@ on:
         description: 'Machine type for the VM (e.g., e2-medium). Default from variables.tf will be used if empty.'
         required: false
         type: string
-      disk_size_gb:
-        description: 'It is an integer. Boot disk size in GB. Default from variables.tf will be used if empty.'
-        required: false
-        type: string 
       disk_type:
         description: 'Boot disk type (e.g., pd-standard). Default from variables.tf will be used if empty.'
         required: false
@@ -57,10 +45,6 @@ on:
         type: string
       boot_disk_image:
         description: 'Boot disk image to use (overrides snapshot). Default from variables.tf will be used if empty (null).'
-        required: false
-        type: string
-      snapshot_retention_days:
-        description: 'It is an integer. Number of days to retain snapshots. Default from variables.tf will be used if empty.'
         required: false
         type: string
 
@@ -111,17 +95,13 @@ jobs:
         env:
           TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
           TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
-          TF_VAR_region: ${{ github.event.inputs.region }}
-          TF_VAR_zone: ${{ github.event.inputs.zone }}
           TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
           TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
-          TF_VAR_disk_size_gb: ${{ github.event.inputs.disk_size_gb }}
           TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
           TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
           TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
           TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
           TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
-          TF_VAR_snapshot_retention_days: ${{ github.event.inputs.snapshot_retention_days }}
         run: terraform plan -out=tfplan -input=false
         continue-on-error: false
 
@@ -130,17 +110,13 @@ jobs:
         env:
           TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
           TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
-          TF_VAR_region: ${{ github.event.inputs.region }}
-          TF_VAR_zone: ${{ github.event.inputs.zone }}
           TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
           TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
-          TF_VAR_disk_size_gb: ${{ github.event.inputs.disk_size_gb }}
           TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
           TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
           TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
           TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
           TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
-          TF_VAR_snapshot_retention_days: ${{ github.event.inputs.snapshot_retention_days }}
         run: terraform apply -auto-approve -input=false tfplan
 
       - name: Terraform Destroy
@@ -148,15 +124,11 @@ jobs:
         env:
           TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
           TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
-          TF_VAR_region: ${{ github.event.inputs.region }}
-          TF_VAR_zone: ${{ github.event.inputs.zone }}
           TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
           TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
-          TF_VAR_disk_size_gb: ${{ github.event.inputs.disk_size_gb }}
           TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
           TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
           TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
           TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
           TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
-          TF_VAR_snapshot_retention_days: ${{ github.event.inputs.snapshot_retention_days }}
         run: terraform destroy -auto-approve -input=false

--- a/.github/workflows/deploy_vm_staging.yml
+++ b/.github/workflows/deploy_vm_staging.yml
@@ -22,14 +22,6 @@ on:
         description: 'GCP Project ID for snapshots. Default from variables.tf will be used if empty.'
         required: false
         type: string
-      region:
-        description: 'GCP Region (e.g., us-west1). Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      zone:
-        description: 'GCP Zone (e.g., us-west1-a). Default from variables.tf will be used if empty.'
-        required: false
-        type: string
       vm_name:
         description: 'Name for the VM (e.g., ubyssey-staging-vm). Default from variables.tf will be used if empty.'
         required: false
@@ -38,10 +30,6 @@ on:
         description: 'Machine type for the VM (e.g., e2-medium). Default from variables.tf will be used if empty.'
         required: false
         type: string
-      disk_size_gb:
-        description: 'It is an integer. Boot disk size in GB. Default from variables.tf will be used if empty.'
-        required: false
-        type: string 
       disk_type:
         description: 'Boot disk type (e.g., pd-standard). Default from variables.tf will be used if empty.'
         required: false
@@ -60,10 +48,6 @@ on:
         type: string
       boot_disk_image:
         description: 'Boot disk image to use (overrides snapshot). Default from variables.tf will be used if empty (null).'
-        required: false
-        type: string
-      snapshot_retention_days:
-        description: 'It is an integer. Number of days to retain snapshots. Default from variables.tf will be used if empty.'
         required: false
         type: string
 
@@ -114,17 +98,13 @@ jobs:
         env:
           TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
           TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
-          TF_VAR_region: ${{ github.event.inputs.region }}
-          TF_VAR_zone: ${{ github.event.inputs.zone }}
           TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
           TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
-          TF_VAR_disk_size_gb: ${{ github.event.inputs.disk_size_gb }}
           TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
           TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
           TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
           TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
           TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
-          TF_VAR_snapshot_retention_days: ${{ github.event.inputs.snapshot_retention_days }}
         run: terraform plan -out=tfplan -input=false
         continue-on-error: false
 
@@ -133,17 +113,13 @@ jobs:
         env:
           TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
           TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
-          TF_VAR_region: ${{ github.event.inputs.region }}
-          TF_VAR_zone: ${{ github.event.inputs.zone }}
           TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
           TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
-          TF_VAR_disk_size_gb: ${{ github.event.inputs.disk_size_gb }}
           TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
           TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
           TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
           TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
           TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
-          TF_VAR_snapshot_retention_days: ${{ github.event.inputs.snapshot_retention_days }}
         run: terraform apply -auto-approve -input=false tfplan
 
       - name: Terraform Destroy
@@ -151,15 +127,11 @@ jobs:
         env:
           TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
           TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
-          TF_VAR_region: ${{ github.event.inputs.region }}
-          TF_VAR_zone: ${{ github.event.inputs.zone }}
           TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
           TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
-          TF_VAR_disk_size_gb: ${{ github.event.inputs.disk_size_gb }}
           TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
           TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
           TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
           TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
           TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
-          TF_VAR_snapshot_retention_days: ${{ github.event.inputs.snapshot_retention_days }}
         run: terraform destroy -auto-approve -input=false

--- a/.github/workflows/deploy_vm_staging.yml
+++ b/.github/workflows/deploy_vm_staging.yml
@@ -14,42 +14,6 @@ on:
         options:
           - deploy
           - destroy
-      project_provider:
-        description: 'GCP Project ID for the provider (e.g., ubyssey-staging). Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      project_snapshot:
-        description: 'GCP Project ID for snapshots. Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      vm_name:
-        description: 'Name for the VM (e.g., ubyssey-staging-vm). Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      machine_type:
-        description: 'Machine type for the VM (e.g., e2-medium). Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      disk_type:
-        description: 'Boot disk type (e.g., pd-standard). Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      snapshot_filter:
-        description: 'Filter for selecting the snapshot. Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      service_account_email:
-        description: 'Service account email for the VM. Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      boot_disk_from_snapshot:
-        description: 'Name for the boot disk created from snapshot. Default from variables.tf will be used if empty.'
-        required: false
-        type: string
-      boot_disk_image:
-        description: 'Boot disk image to use (overrides snapshot). Default from variables.tf will be used if empty (null).'
-        required: false
-        type: string
 
 permissions:
   contents: 'read'
@@ -95,43 +59,13 @@ jobs:
       - name: Terraform Plan
         id: plan
         if: steps.get_action.outputs.action == 'deploy'
-        env:
-          TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
-          TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
-          TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
-          TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
-          TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
-          TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
-          TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
-          TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
-          TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
         run: terraform plan -out=tfplan -input=false
         continue-on-error: false
 
       - name: Terraform Apply
         if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
-        env:
-          TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
-          TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
-          TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
-          TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
-          TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
-          TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
-          TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
-          TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
-          TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
         run: terraform apply -auto-approve -input=false tfplan
 
       - name: Terraform Destroy
         if: steps.get_action.outputs.action == 'destroy'
-        env:
-          TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
-          TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
-          TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
-          TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
-          TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
-          TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
-          TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
-          TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
-          TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
         run: terraform destroy -auto-approve -input=false

--- a/.github/workflows/deploy_vm_staging.yml
+++ b/.github/workflows/deploy_vm_staging.yml
@@ -14,6 +14,58 @@ on:
         options:
           - deploy
           - destroy
+      project_provider:
+        description: 'GCP Project ID for the provider (e.g., ubyssey-staging). Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      project_snapshot:
+        description: 'GCP Project ID for snapshots. Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      region:
+        description: 'GCP Region (e.g., us-west1). Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      zone:
+        description: 'GCP Zone (e.g., us-west1-a). Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      vm_name:
+        description: 'Name for the VM (e.g., ubyssey-staging-vm). Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      machine_type:
+        description: 'Machine type for the VM (e.g., e2-medium). Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      disk_size_gb:
+        description: 'It is an integer. Boot disk size in GB. Default from variables.tf will be used if empty.'
+        required: false
+        type: string 
+      disk_type:
+        description: 'Boot disk type (e.g., pd-standard). Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      snapshot_filter:
+        description: 'Filter for selecting the snapshot. Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      service_account_email:
+        description: 'Service account email for the VM. Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      boot_disk_from_snapshot:
+        description: 'Name for the boot disk created from snapshot. Default from variables.tf will be used if empty.'
+        required: false
+        type: string
+      boot_disk_image:
+        description: 'Boot disk image to use (overrides snapshot). Default from variables.tf will be used if empty (null).'
+        required: false
+        type: string
+      snapshot_retention_days:
+        description: 'It is an integer. Number of days to retain snapshots. Default from variables.tf will be used if empty.'
+        required: false
+        type: string
 
 permissions:
   contents: 'read'
@@ -21,7 +73,7 @@ permissions:
 
 jobs:
   terraform:
-    name: 'Terraform ${{ github.event.inputs.action || ''deploy'' }}' 
+    name: 'Terraform ${{ github.event.inputs.action || ''deploy'' }}'
     runs-on: ubuntu-latest
 
     defaults:
@@ -42,7 +94,7 @@ jobs:
         with:
           workload_identity_provider: 'projects/1012602718138/locations/global/workloadIdentityPools/ubyssey-wif-pool-staging/providers/ubyssey-oidc-github-staging'
           service_account: 'deployment@ubyssey-staging.iam.gserviceaccount.com'
-                    
+
       - name: Determine Action
         id: get_action
         run: |
@@ -59,13 +111,55 @@ jobs:
       - name: Terraform Plan
         id: plan
         if: steps.get_action.outputs.action == 'deploy'
+        env:
+          TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
+          TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
+          TF_VAR_region: ${{ github.event.inputs.region }}
+          TF_VAR_zone: ${{ github.event.inputs.zone }}
+          TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
+          TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
+          TF_VAR_disk_size_gb: ${{ github.event.inputs.disk_size_gb }}
+          TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
+          TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
+          TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
+          TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
+          TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
+          TF_VAR_snapshot_retention_days: ${{ github.event.inputs.snapshot_retention_days }}
         run: terraform plan -out=tfplan -input=false
-        continue-on-error: false 
+        continue-on-error: false
 
       - name: Terraform Apply
         if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
+        env:
+          TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
+          TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
+          TF_VAR_region: ${{ github.event.inputs.region }}
+          TF_VAR_zone: ${{ github.event.inputs.zone }}
+          TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
+          TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
+          TF_VAR_disk_size_gb: ${{ github.event.inputs.disk_size_gb }}
+          TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
+          TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
+          TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
+          TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
+          TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
+          TF_VAR_snapshot_retention_days: ${{ github.event.inputs.snapshot_retention_days }}
         run: terraform apply -auto-approve -input=false tfplan
 
       - name: Terraform Destroy
         if: steps.get_action.outputs.action == 'destroy'
+        env:
+          TF_VAR_project_provider: ${{ github.event.inputs.project_provider }}
+          TF_VAR_project_snapshot: ${{ github.event.inputs.project_snapshot }}
+          TF_VAR_region: ${{ github.event.inputs.region }}
+          TF_VAR_zone: ${{ github.event.inputs.zone }}
+          TF_VAR_vm_name: ${{ github.event.inputs.vm_name }}
+          TF_VAR_machine_type: ${{ github.event.inputs.machine_type }}
+          TF_VAR_disk_size_gb: ${{ github.event.inputs.disk_size_gb }}
+          TF_VAR_disk_type: ${{ github.event.inputs.disk_type }}
+          TF_VAR_snapshot_filter: ${{ github.event.inputs.snapshot_filter }}
+          TF_VAR_service_account_email: ${{ github.event.inputs.service_account_email }}
+          TF_VAR_boot_disk_from_snapshot: ${{ github.event.inputs.boot_disk_from_snapshot }}
+          TF_VAR_boot_disk_image: ${{ github.event.inputs.boot_disk_image }}
+          TF_VAR_snapshot_retention_days: ${{ github.event.inputs.snapshot_retention_days }}
         run: terraform destroy -auto-approve -input=false

--- a/.github/workflows/deploy_vm_staging.yml
+++ b/.github/workflows/deploy_vm_staging.yml
@@ -1,9 +1,6 @@
 name: Terraform GCP VM Deployment
 
 on:
-  push:
-    branches:
-      - automate-deploying-vm
   workflow_dispatch:
     inputs:
       action:

--- a/.github/workflows/deploy_vm_staging.yml
+++ b/.github/workflows/deploy_vm_staging.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Terraform Init
         id: init
-        run: terraform init
+        run: terraform init -backend-config=backend-staging.conf
 
       - name: Terraform Plan
         id: plan

--- a/.github/workflows/deploy_vm_staging.yml
+++ b/.github/workflows/deploy_vm_staging.yml
@@ -1,0 +1,71 @@
+name: Terraform GCP VM Deployment
+
+on:
+  push:
+    branches:
+      - automate-deploying-vm
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Terraform action to perform (deploy or destroy)'
+        required: true
+        default: 'deploy'
+        type: choice
+        options:
+          - deploy
+          - destroy
+
+permissions:
+  contents: 'read'
+  id-token: 'write'
+
+jobs:
+  terraform:
+    name: 'Terraform ${{ github.event.inputs.action || ''deploy'' }}' 
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./deploy-vm
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.11.3"
+
+      - name: Authenticate with Google Cloud Platform
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: 'projects/1012602718138/locations/global/workloadIdentityPools/ubyssey-wif-pool-staging/providers/ubyssey-oidc-github-staging'
+          service_account: 'deployment@ubyssey-staging.iam.gserviceaccount.com'
+                    
+      - name: Determine Action
+        id: get_action
+        run: |
+          ACTION="deploy" # Default for push events
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            ACTION="${{ github.event.inputs.action }}"
+          fi
+          echo "action=$ACTION" >> $GITHUB_OUTPUT
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Plan
+        id: plan
+        if: steps.get_action.outputs.action == 'deploy'
+        run: terraform plan -out=tfplan -input=false
+        continue-on-error: false 
+
+      - name: Terraform Apply
+        if: steps.get_action.outputs.action == 'deploy' && steps.plan.outcome == 'success'
+        run: terraform apply -auto-approve -input=false tfplan
+
+      - name: Terraform Destroy
+        if: steps.get_action.outputs.action == 'destroy'
+        run: terraform destroy -auto-approve -input=false

--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,5 @@ ubyssey/settings*.py
 *.tfstate
 *.tfstate.*
 .terraform.lock.hcl
-*.zip
 mysql-data
+*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,10 @@ pyvenv.cfg
 
 ubyssey/settings*.py
 
+# Terraform files
+.terraform
+*.tfstate
+*.tfstate.*
+.terraform.lock.hcl
+*.zip
 mysql-data

--- a/certbot-init.sh
+++ b/certbot-init.sh
@@ -1,1 +1,2 @@
 docker compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ -d ubyssey.ca
+docker compose run --rm certbot certonly --webroot --webroot-path /var/www/certbot/ -d staging.ubyssey.ca

--- a/deploy-vm/backend-production.conf
+++ b/deploy-vm/backend-production.conf
@@ -1,0 +1,2 @@
+bucket = "ubyssey-terraform-state-bucket-prd"
+prefix = "terraform/state"

--- a/deploy-vm/backend-staging.conf
+++ b/deploy-vm/backend-staging.conf
@@ -1,0 +1,2 @@
+bucket = "ubyssey-terraform-state-bucket"
+prefix = "terraform/state"

--- a/deploy-vm/deploy.sh
+++ b/deploy-vm/deploy.sh
@@ -13,7 +13,7 @@ GCLOUD_SDK_PARENT_DIR="/opt"
 GCLOUD_SDK_INSTALL_DIR="${GCLOUD_SDK_PARENT_DIR}/google-cloud-sdk"
 TEMP_SDK_DOWNLOAD_DIR=$(mktemp -d)
 TEMP_DIR=$(mktemp -d)
-TARGET_PROJECT_ID="ubyssey-prd"
+TARGET_PROJECT_ID="ubyssey-staging"
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # --- Color definitions ---

--- a/deploy-vm/deploy.sh
+++ b/deploy-vm/deploy.sh
@@ -123,6 +123,8 @@ install_gcloud_sdk() {
     fi
 }
 
+# --- Main functions ---
+
 install_terraform() {
   # Check if Terraform is installed
   if command -v terraform &> /dev/null; then
@@ -169,7 +171,10 @@ install_terraform() {
   
   log "Unzipping ${TERRAFORM_ZIP}..."
   unzip "${TERRAFORM_ZIP}" || error_exit "Failed to unzip ${TERRAFORM_ZIP}."
-  
+
+  log "Removing downloaded Terraform zip file: ${TERRAFORM_ZIP}..."
+  rm -f "${TERRAFORM_ZIP}" || warn "Could not remove Terraform zip file: ${TERRAFORM_ZIP}"
+
   log "Moving Terraform to ${TERRAFORM_BIN}..."
   mkdir -p "${TERRAFORM_DIR}" || error_exit "Failed to create directory ${TERRAFORM_DIR}. Check permissions."
   mv terraform "${TERRAFORM_BIN}" || error_exit "Failed to move Terraform to ${TERRAFORM_BIN}."

--- a/deploy-vm/deploy.sh
+++ b/deploy-vm/deploy.sh
@@ -1,0 +1,251 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# --- Variables ---
+TERRAFORM_VERSION="1.11.3"
+TERRAFORM_DIR="/usr/local/bin"
+TERRAFORM_ZIP="terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${TERRAFORM_ZIP}"
+TERRAFORM_BIN="${TERRAFORM_DIR}/terraform"
+GCLOUD_SDK_PARENT_DIR="/opt" 
+GCLOUD_SDK_INSTALL_DIR="${GCLOUD_SDK_PARENT_DIR}/google-cloud-sdk"
+TEMP_SDK_DOWNLOAD_DIR=$(mktemp -d)
+TEMP_DIR=$(mktemp -d)
+TARGET_PROJECT_ID="ubyssey-prd"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# --- Color definitions ---
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+# --- Helper Functions ---
+log() {
+  echo -e "${GREEN}[INFO] $(date +'%Y-%m-%d %H:%M:%S') - $1${NC}"
+}
+
+error_exit() {
+  echo -e "${RED}[ERROR] $(date +'%Y-%m-%d %H:%M:%S') - $1${NC}" >&2
+  exit 1
+}
+
+warn() {
+   echo -e "${YELLOW}[WARN] $(date +'%Y-%m-%d %H:%M:%S') - $1${NC}"
+}
+
+usage() {
+  echo -e "${YELLOW}Usage: $0 <action>${NC}"
+  echo -e ""
+  echo -e "${YELLOW}Actions:${NC}"
+  echo -e "  ${GREEN}deploy${NC}   - Initialize, plan, and apply Terraform configuration to deploy resources."
+  echo -e "  ${GREEN}destroy${NC}  - Initialize and destroy Terraform-managed resources."
+  echo -e ""
+  echo -e "${YELLOW}Options:${NC}"
+  echo -e "  ${GREEN}--help${NC}   - Display this help message."
+  exit 1 # Exit with an error code as usage implies incorrect invocation or help request
+}
+
+set_gcp_project_id() {
+  log "Checking current active gcloud project..."
+  CURRENT_ACTIVE_PROJECT=$(gcloud config get-value project 2>/dev/null)
+
+  if [ "$CURRENT_ACTIVE_PROJECT" == "$TARGET_PROJECT_ID" ]; then
+    log "Active gcloud project is already set to '${TARGET_PROJECT_ID}'. No changes needed."
+  else
+    if gcloud projects describe "${TARGET_PROJECT_ID}" --format="value(projectId)" > /dev/null 2>&1; then
+      log "Setting active gcloud project to '${TARGET_PROJECT_ID}'..."
+      gcloud config set project "${TARGET_PROJECT_ID}" || error_exit "Failed to set gcloud project to '${TARGET_PROJECT_ID}'."
+    else
+      error_exit "Project '${TARGET_PROJECT_ID}' does not exist, or you do not have permission to access it. Please check the project ID and your IAM permissions."
+    fi
+  fi
+}
+
+authorize_gcp(){
+  log "Checking current gcloud user authentication status..."
+  ACTIVE_USER_ACCOUNT=$(gcloud auth list --filter=status:ACTIVE --format="value(account)" 2>/dev/null)
+
+  if [ -n "$ACTIVE_USER_ACCOUNT" ]; then
+    log "Already logged in to gcloud as: $ACTIVE_USER_ACCOUNT"
+  else
+    warn "No active gcloud user login found. Attempting 'gcloud auth login'..."
+    log "This will likely open a web browser for authentication."
+    if gcloud auth login; then
+      log "'gcloud auth login' successful."
+      ACTIVE_USER_ACCOUNT=$(gcloud auth list --filter=status:ACTIVE --format="value(account)" 2>/dev/null) # Re-check
+      log "Now logged in as: $ACTIVE_USER_ACCOUNT"
+    fi
+  fi
+}
+
+install_gcloud_sdk() {
+    log "gcloud CLI not found. Attempting to install Google Cloud SDK..."
+    
+    mkdir -p "${GCLOUD_SDK_PARENT_DIR}" || error_exit "Failed to create parent directory ${GCLOUD_SDK_PARENT_DIR}. Check permissions."
+
+    # Ensure TEMP_SDK_DOWNLOAD_DIR is cleaned up on script exit
+    trap 'rm -rf -- "$TEMP_SDK_DOWNLOAD_DIR"' EXIT
+
+    cd "$TEMP_SDK_DOWNLOAD_DIR"
+
+    log "Downloading Google Cloud SDK..."
+    # Using the general tar.gz for broader compatibility
+    curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz
+
+    log "Extracting Google Cloud SDK to ${GCLOUD_SDK_INSTALL_DIR}..."
+    mkdir -p "${GCLOUD_SDK_INSTALL_DIR}"
+    tar -xzf google-cloud-cli-linux-x86_64.tar.gz --strip-components=1 -C "${GCLOUD_SDK_INSTALL_DIR}" || error_exit "Failed to extract Google Cloud SDK."
+    
+    SDK_PATH_INC="${GCLOUD_SDK_INSTALL_DIR}/path.bash.inc"
+
+    log "Running Google Cloud SDK installation script..."
+    "${GCLOUD_SDK_INSTALL_DIR}/install.sh"
+
+    if [ -f "$SDK_PATH_INC" ]; then
+        log "Sourcing Google Cloud SDK path for current session from $SDK_PATH_INC"
+        source "$SDK_PATH_INC"
+    else
+        log "Could not find $SDK_PATH_INC. Adding SDK bin to PATH manually for current session."
+        export PATH="${GCLOUD_SDK_INSTALL_DIR}/bin:$PATH"
+    fi
+    
+    cd - > /dev/null # Go back to original directory
+    trap - EXIT # Clear the trap for TEMP_SDK_DOWNLOAD_DIR
+
+    if ! command -v gcloud &> /dev/null; then
+      error_exit "Google Cloud SDK installation attempted, but 'gcloud' command is still not found. Please check the installation output or install manually."
+    else
+      log "Google Cloud SDK installed successfully."
+      gcloud --version
+    fi
+}
+
+install_terraform() {
+  # Check if Terraform is installed
+  if command -v terraform &> /dev/null; then
+    # Terraform is installed, let's check the version
+    INSTALLED_VERSION_FULL_STRING=$(terraform version | head -n 1)
+    INSTALLED_VERSION_NUMBER=$(echo "$INSTALLED_VERSION_FULL_STRING" | grep -oP 'v\K[0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9]+)?')
+
+    if [ -n "$INSTALLED_VERSION_NUMBER" ] && [ "$INSTALLED_VERSION_NUMBER" == "$TERRAFORM_VERSION" ]; then
+      log "Terraform v${TERRAFORM_VERSION} is already installed and matches the required version."
+      return 0 # Exit the function successfully
+    else
+      if [ -n "$INSTALLED_VERSION_NUMBER" ]; then
+        warn "Installed Terraform version (v${INSTALLED_VERSION_NUMBER}) does NOT match the required version (v${TERRAFORM_VERSION})."
+      else
+        warn "Could not reliably parse installed Terraform version from: '${INSTALLED_VERSION_FULL_STRING}'. Assuming mismatch."
+      fi
+      log "Removing existing Terraform to install v${TERRAFORM_VERSION}..."
+      # Attempt to find the full path of the existing terraform binary
+      EXISTING_TERRAFORM_PATH=$(command -v terraform)
+      if [ -n "$EXISTING_TERRAFORM_PATH" ] && [ -f "$EXISTING_TERRAFORM_PATH" ]; then
+        rm -f "$EXISTING_TERRAFORM_PATH" || warn "Could not remove existing Terraform binary at '${EXISTING_TERRAFORM_PATH}'. Please check permissions. Installation will proceed to ${TERRAFORM_BIN}."
+      else
+        warn "Could not determine the path of the existing Terraform binary to remove it."
+      fi
+    fi
+  fi
+
+  # This part will run if Terraform is not installed OR if it was removed due to version mismatch
+  log "Terraform not found or version mismatch. Installing Terraform v${TERRAFORM_VERSION}..."
+  
+  # Install dependencies if not present (curl, unzip)
+  if ! command -v curl &> /dev/null || ! command -v unzip &> /dev/null; then
+      log "Installing curl and unzip..."
+      apt-get update && apt-get install -y curl unzip || error_exit "Failed to install curl/unzip."
+  fi
+
+  # Ensure TEMP_DIR is cleaned up on script exit, even if by error
+  trap 'rm -rf -- "$TEMP_DIR"' EXIT
+
+  cd "$TEMP_DIR"
+
+  log "Downloading Terraform v${TERRAFORM_VERSION} from ${TERRAFORM_URL}..."
+  curl -Os "${TERRAFORM_URL}" || error_exit "Failed to download Terraform from ${TERRAFORM_URL}."
+  
+  log "Unzipping ${TERRAFORM_ZIP}..."
+  unzip "${TERRAFORM_ZIP}" || error_exit "Failed to unzip ${TERRAFORM_ZIP}."
+  
+  log "Moving Terraform to ${TERRAFORM_BIN}..."
+  mkdir -p "${TERRAFORM_DIR}" || error_exit "Failed to create directory ${TERRAFORM_DIR}. Check permissions."
+  mv terraform "${TERRAFORM_BIN}" || error_exit "Failed to move Terraform to ${TERRAFORM_BIN}."
+  chmod +x "${TERRAFORM_BIN}"
+
+  cd - > /dev/null # Go back to original directory
+  # trap will clean up TEMP_DIR, but we can remove it here if we want to be explicit before trap fires
+  rm -rf -- "$TEMP_DIR"
+  trap - EXIT # Clear the trap as we've manually cleaned up
+
+  log "Terraform v${TERRAFORM_VERSION} installed successfully to ${TERRAFORM_BIN}."
+}
+
+login_gcp() {
+  log "Ensuring gcloud CLI is available..."
+  if ! command -v gcloud &> /dev/null; then
+    install_gcloud_sdk 
+  else
+    log "gcloud CLI is already installed."
+  fi
+  authorize_gcp
+  set_gcp_project_id
+}
+
+run_terraform_workflow() {
+  local action="$1"
+
+  log "Starting Terraform workflow for action: ${action}..."
+
+  cd "$SCRIPT_DIR"
+  log "Running 'terraform init'..."
+  terraform init || error_exit "Terraform init failed."
+
+  if [ "$action" == "apply" ]; then
+    log "Running 'terraform plan'..."
+    terraform plan || error_exit "Terraform plan failed."
+
+    log "Terraform will now ask for confirmation to apply the plan."
+    terraform apply || error_exit "Terraform apply failed."
+  
+  elif [ "$action" == "destroy" ]; then
+    log "Terraform will now ask for confirmation to destroy resources."
+    terraform destroy || error_exit "Terraform destroy failed." 
+    log "Terraform destroy completed successfully."
+    
+  else
+    error_exit "Invalid action specified for Terraform workflow: ${action}. Use 'apply' or 'destroy'."
+  fi
+}
+
+# --- Script Execution ---
+main() {
+  log "Starting GCP VM Deployment Script..."
+
+  if [ "$1" == "--help" ]; then
+    usage
+  fi
+  
+  local action="$1"
+  
+  # Validate the input argument
+  if [ -z "$1" ] || [[ "$action" != "deploy" && "$action" != "destroy" ]]; then
+    echo -e "${RED}[ERROR] Invalid action: '${action}'.${NC}" >&2
+    usage 
+  fi
+
+  install_terraform
+  login_gcp 
+
+  if [ "$action" == "deploy" ]; then
+    run_terraform_workflow "apply"
+  else
+    run_terraform_workflow "destroy"
+  fi
+
+  log "Script finished successfully for action: ${action}!"
+}
+
+main "$@"

--- a/deploy-vm/main.tf
+++ b/deploy-vm/main.tf
@@ -25,6 +25,12 @@ resource "google_compute_disk" "boot_disk_from_snapshot" {
   image    = var.boot_disk_image
 }
 
+resource "google_compute_address" "vm_static_ip" {
+  name         = "${var.vm_name}-static-ip"
+  address_type = "EXTERNAL"
+  region       = var.region
+}
+
 resource "google_compute_instance" "ubyssey_vm" {
   name                      = var.vm_name
   machine_type              = var.machine_type
@@ -41,6 +47,7 @@ resource "google_compute_instance" "ubyssey_vm" {
     network    = "default"
     subnetwork = "default"
     access_config {
+      nat_ip = google_compute_address.vm_static_ip.address
     }
   }
 

--- a/deploy-vm/main.tf
+++ b/deploy-vm/main.tf
@@ -4,49 +4,69 @@ provider "google" {
   zone    = "us-west1-a"
 }
 
+data "google_compute_snapshot" "ubyssey_snapshot" {
+  name    = "ubyssey-prd-vm-1-us-west1-a-20250504090431-kiy1orqn"
+  project = "ubyssey-prd"
+}
+
+# Optional: Generate a random suffix for the disk name to ensure uniqueness
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+# 1. Create a new disk from the snapshot to be used as the boot disk
+resource "google_compute_disk" "boot_disk_from_snapshot" {
+  name  = "boot-disk-from-snapshot-${random_id.suffix.hex}" # Use a unique name, e.g., with a random suffix
+  zone  = "us-west1-a"
+  type  = "pd-standard"
+  # The size of the new disk must be at least the size of the snapshot's source disk.
+  # You can explicitly set a size if needed, otherwise it will default to the snapshot size.
+  # size = 40 # Example: explicitly setting size
+
+  # CORRECTED: Use the 'snapshot' argument to specify the source snapshot
+  snapshot = data.google_compute_snapshot.ubyssey_snapshot.self_link
+}
+
+
 resource "google_compute_instance" "ubyssey_prd_vm_2" {
   name         = "ubyssey-prd-vm-2"
   machine_type = "e2-highcpu-8"
-  zone         = "us-west1-a"
+  zone         = "us-west1-a" # Must be in the same zone as the boot disk
   description  = ""
   allow_stopping_for_update = true
-  
+
+  # 2. Reference the newly created disk in the boot_disk block
   boot_disk {
     auto_delete = true
-    device_name = "ubyssey-prd-vm-2"
+    # Use the 'source' argument to attach the disk created from the snapshot
+    source = google_compute_disk.boot_disk_from_snapshot.self_link
+  }
 
-    initialize_params {
-      size = 40
-      image = "projects/debian-cloud/global/images/family/debian-12"
-      type = "pd-standard"
-    }
-  }  
   network_interface {
     network    = "default"
     subnetwork = "default"
     access_config {
     }
   }
-  
+
   scheduling {
     automatic_restart   = true
     on_host_maintenance = "MIGRATE"
     preemptible         = false
     provisioning_model  = "STANDARD"
   }
-    
+
   metadata = {
     enable-osconfig = "TRUE"
   }
-  
+
   tags = ["http-server", "https-server"]
-  
+
   labels = {
     goog-ops-agent-policy = "v2-x86-template-1-4-0"
   }
-  
+
   reservation_affinity {
     type = "ANY_RESERVATION"
   }
-  
 }

--- a/deploy-vm/main.tf
+++ b/deploy-vm/main.tf
@@ -1,5 +1,8 @@
 terraform {
-  backend "gcs" {}
+  backend "gcs" {
+    bucket = "ubyssey-terraform-state-bucket"
+    prefix = "terraform/state"
+  }
 }
 
 provider "google" {

--- a/deploy-vm/main.tf
+++ b/deploy-vm/main.tf
@@ -65,10 +65,10 @@ resource "google_compute_instance" "ubyssey_vm" {
     type = "ANY_RESERVATION"
   }
 
-  # service_account {
-  #   email  = var.service_account_email
-  #   scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-  # }
+  service_account {
+    email  = var.service_account_email
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
 }
 
 # Resource policy for automatic snapshot schedule and retention

--- a/deploy-vm/main.tf
+++ b/deploy-vm/main.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "gcs" {
-    bucket = "ubyssey-terraform-state-bucket"
+    bucket = var.gcs_bucket
     prefix = "terraform-state"
   }
 }

--- a/deploy-vm/main.tf
+++ b/deploy-vm/main.tf
@@ -1,11 +1,18 @@
+terraform {
+  backend "gcs" {
+    bucket = "ubyssey-terraform-state-bucket"
+    prefix = "terraform-state"
+  }
+}
+
 provider "google" {
-  project = var.project
+  project = var.project_provider
   region  = var.region
   zone    = var.zone
 }
 
 data "google_compute_snapshot" "ubyssey_snapshot" {
-  project     = var.project
+  project     = var.project_snapshot
   filter      = var.snapshot_filter
   most_recent = true
 }
@@ -58,10 +65,10 @@ resource "google_compute_instance" "ubyssey_prd_vm_2" {
     type = "ANY_RESERVATION"
   }
 
-  service_account {
-    email  = var.service_account_email
-    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-  }
+  # service_account {
+  #   email  = var.service_account_email
+  #   scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  # }
 }
 
 # Resource policy for automatic snapshot schedule and retention

--- a/deploy-vm/main.tf
+++ b/deploy-vm/main.tf
@@ -1,34 +1,28 @@
 provider "google" {
-  project = "ubyssey-prd"
-  region  = "us-west1"
-  zone    = "us-west1-a"
+  project = var.project
+  region  = var.region
+  zone    = var.zone
 }
 
 data "google_compute_snapshot" "ubyssey_snapshot" {
-  project     = "ubyssey-prd"
-  filter      = "name eq ^ubyssey-prd-vm.*"
+  project     = var.project
+  filter      = var.snapshot_filter
   most_recent = true
 }
 
-resource "random_id" "suffix" {
-  byte_length = 4
-}
-//TODO: add snapshot of the disk
-
 resource "google_compute_disk" "boot_disk_from_snapshot" {
-  name     = "boot-disk-from-snapshot-${random_id.suffix.hex}"
-  size     = 40
-  type     = "pd-balanced"
-  snapshot = data.google_compute_snapshot.ubyssey_snapshot.self_link
+  name     = var.boot_disk_from_snapshot
+  size     = var.disk_size_gb
+  type     = var.disk_type
+  snapshot = var.boot_disk_image != null ? null : data.google_compute_snapshot.ubyssey_snapshot.self_link
+  image    = var.boot_disk_image
 }
 
-//TODO: update name
 resource "google_compute_instance" "ubyssey_prd_vm_2" {
-  name                      = "ubyssey-prd-vm-2"
-  //TODO: create a variable for the name
-  machine_type              = "e2-highcpu-8"
-  zone                      = "us-west1-a"
-  description               = ""
+  name                      = var.vm_name
+  machine_type              = var.machine_type
+  zone                      = var.zone
+  description               = "the single VM for ubyssey.ca"
   allow_stopping_for_update = true
 
   boot_disk {
@@ -51,9 +45,9 @@ resource "google_compute_instance" "ubyssey_prd_vm_2" {
   }
 
   metadata = {
-    startup-script = "sudo ufw allow 22"
     enable-osconfig = "TRUE"
   }
+  
   tags = ["http-server", "https-server"]
 
   labels = {
@@ -65,7 +59,7 @@ resource "google_compute_instance" "ubyssey_prd_vm_2" {
   }
 
   service_account {
-    email  = "863738545301-compute@developer.gserviceaccount.com"
+    email  = var.service_account_email
     scopes = ["https://www.googleapis.com/auth/cloud-platform"]
   }
 }

--- a/deploy-vm/main.tf
+++ b/deploy-vm/main.tf
@@ -1,0 +1,52 @@
+provider "google" {
+  project = "ubyssey-prd"
+  region  = "us-west1"
+  zone    = "us-west1-a"
+}
+
+resource "google_compute_instance" "ubyssey_prd_vm_2" {
+  name         = "ubyssey-prd-vm-2"
+  machine_type = "e2-highcpu-8"
+  zone         = "us-west1-a"
+  description  = ""
+  allow_stopping_for_update = true
+  
+  boot_disk {
+    auto_delete = true
+    device_name = "ubyssey-prd-vm-2"
+
+    initialize_params {
+      size = 40
+      image = "projects/debian-cloud/global/images/family/debian-12"
+      type = "pd-standard"
+    }
+  }  
+  network_interface {
+    network    = "default"
+    subnetwork = "default"
+    access_config {
+    }
+  }
+  
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    preemptible         = false
+    provisioning_model  = "STANDARD"
+  }
+    
+  metadata = {
+    enable-osconfig = "TRUE"
+  }
+  
+  tags = ["http-server", "https-server"]
+  
+  labels = {
+    goog-ops-agent-policy = "v2-x86-template-1-4-0"
+  }
+  
+  reservation_affinity {
+    type = "ANY_RESERVATION"
+  }
+  
+}

--- a/deploy-vm/main.tf
+++ b/deploy-vm/main.tf
@@ -10,8 +10,6 @@ data "google_compute_snapshot" "ubyssey_snapshot" {
   most_recent = true
 }
 
-//TODO: add snapshot of the disk
-
 resource "google_compute_disk" "boot_disk_from_snapshot" {
   name     = var.boot_disk_from_snapshot
   size     = var.disk_size_gb
@@ -49,7 +47,7 @@ resource "google_compute_instance" "ubyssey_prd_vm_2" {
   metadata = {
     enable-osconfig = "TRUE"
   }
-  
+
   tags = ["http-server", "https-server"]
 
   labels = {

--- a/deploy-vm/main.tf
+++ b/deploy-vm/main.tf
@@ -5,41 +5,35 @@ provider "google" {
 }
 
 data "google_compute_snapshot" "ubyssey_snapshot" {
-  name    = "ubyssey-prd-vm-1-us-west1-a-20250504090431-kiy1orqn"
-  project = "ubyssey-prd"
+  project     = "ubyssey-prd"
+  filter      = "name eq ^ubyssey-prd-vm.*"
+  most_recent = true
 }
 
-# Optional: Generate a random suffix for the disk name to ensure uniqueness
 resource "random_id" "suffix" {
   byte_length = 4
 }
+//TODO: add snapshot of the disk
 
-# 1. Create a new disk from the snapshot to be used as the boot disk
 resource "google_compute_disk" "boot_disk_from_snapshot" {
-  name  = "boot-disk-from-snapshot-${random_id.suffix.hex}" # Use a unique name, e.g., with a random suffix
-  zone  = "us-west1-a"
-  type  = "pd-standard"
-  # The size of the new disk must be at least the size of the snapshot's source disk.
-  # You can explicitly set a size if needed, otherwise it will default to the snapshot size.
-  # size = 40 # Example: explicitly setting size
-
-  # CORRECTED: Use the 'snapshot' argument to specify the source snapshot
+  name     = "boot-disk-from-snapshot-${random_id.suffix.hex}"
+  size     = 40
+  type     = "pd-balanced"
   snapshot = data.google_compute_snapshot.ubyssey_snapshot.self_link
 }
 
-
+//TODO: update name
 resource "google_compute_instance" "ubyssey_prd_vm_2" {
-  name         = "ubyssey-prd-vm-2"
-  machine_type = "e2-highcpu-8"
-  zone         = "us-west1-a" # Must be in the same zone as the boot disk
-  description  = ""
+  name                      = "ubyssey-prd-vm-2"
+  //TODO: create a variable for the name
+  machine_type              = "e2-highcpu-8"
+  zone                      = "us-west1-a"
+  description               = ""
   allow_stopping_for_update = true
 
-  # 2. Reference the newly created disk in the boot_disk block
   boot_disk {
     auto_delete = true
-    # Use the 'source' argument to attach the disk created from the snapshot
-    source = google_compute_disk.boot_disk_from_snapshot.self_link
+    source      = google_compute_disk.boot_disk_from_snapshot.self_link
   }
 
   network_interface {
@@ -57,9 +51,9 @@ resource "google_compute_instance" "ubyssey_prd_vm_2" {
   }
 
   metadata = {
+    startup-script = "sudo ufw allow 22"
     enable-osconfig = "TRUE"
   }
-
   tags = ["http-server", "https-server"]
 
   labels = {
@@ -68,5 +62,10 @@ resource "google_compute_instance" "ubyssey_prd_vm_2" {
 
   reservation_affinity {
     type = "ANY_RESERVATION"
+  }
+
+  service_account {
+    email  = "863738545301-compute@developer.gserviceaccount.com"
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
   }
 }

--- a/deploy-vm/main.tf
+++ b/deploy-vm/main.tf
@@ -10,6 +10,8 @@ data "google_compute_snapshot" "ubyssey_snapshot" {
   most_recent = true
 }
 
+//TODO: add snapshot of the disk
+
 resource "google_compute_disk" "boot_disk_from_snapshot" {
   name     = var.boot_disk_from_snapshot
   size     = var.disk_size_gb
@@ -62,4 +64,34 @@ resource "google_compute_instance" "ubyssey_prd_vm_2" {
     email  = var.service_account_email
     scopes = ["https://www.googleapis.com/auth/cloud-platform"]
   }
+}
+
+# Resource policy for automatic snapshot schedule and retention
+resource "google_compute_resource_policy" "snapshot_retention" {
+  name   = "${var.vm_name}-snapshot-policy"
+  region = var.region
+  snapshot_schedule_policy {
+    schedule {
+      daily_schedule {
+        days_in_cycle = 1
+        start_time    = "03:00"
+      }
+    }
+    retention_policy {
+      max_retention_days    = var.snapshot_retention_days
+      on_source_disk_delete = "KEEP_AUTO_SNAPSHOTS"
+    }
+    snapshot_properties {
+      labels = {
+        created_by = "terraform"
+        vm_name    = var.vm_name
+      }
+    }
+  }
+}
+
+resource "google_compute_disk_resource_policy_attachment" "attach_policy" {
+  name = google_compute_resource_policy.snapshot_retention.name
+  disk = google_compute_disk.boot_disk_from_snapshot.name
+  zone = var.zone
 }

--- a/deploy-vm/main.tf
+++ b/deploy-vm/main.tf
@@ -25,7 +25,7 @@ resource "google_compute_disk" "boot_disk_from_snapshot" {
   image    = var.boot_disk_image
 }
 
-resource "google_compute_instance" "ubyssey_prd_vm_2" {
+resource "google_compute_instance" "ubyssey_vm" {
   name                      = var.vm_name
   machine_type              = var.machine_type
   zone                      = var.zone

--- a/deploy-vm/main.tf
+++ b/deploy-vm/main.tf
@@ -1,8 +1,5 @@
 terraform {
-  backend "gcs" {
-    bucket = var.gcs_bucket
-    prefix = "terraform-state"
-  }
+  backend "gcs" {}
 }
 
 provider "google" {

--- a/deploy-vm/outputs.tf
+++ b/deploy-vm/outputs.tf
@@ -1,0 +1,19 @@
+output "vm_static_ip" {
+  description = "The static external IP address of the VM"
+  value       = google_compute_address.vm_static_ip.address
+}
+
+output "vm_internal_ip" {
+  description = "The internal IP address of the VM"
+  value       = google_compute_instance.ubyssey_vm.network_interface[0].network_ip
+}
+
+output "vm_name" {
+  description = "The name of the created VM"
+  value       = google_compute_instance.ubyssey_vm.name
+}
+
+output "vm_zone" {
+  description = "The zone where the VM is located"
+  value       = google_compute_instance.ubyssey_vm.zone
+}

--- a/deploy-vm/terraform-architecture.md
+++ b/deploy-vm/terraform-architecture.md
@@ -7,85 +7,124 @@ This document explains how the components defined in your Terraform script are i
 ## 1. **Google Cloud Storage (GCS) Bucket**
 - **Purpose:** Stores the Terraform state file, which tracks all managed resources.
 - **How:**
-  - Defined in the `terraform` backend block (via `backend.conf`).
-  - Example: `ubyssey-terraform-state-bucket`.
+  - Defined in the `terraform` backend block using `ubyssey-terraform-state-bucket`.
+  - State is stored with prefix `terraform/state`.
 
 ---
 
-## 2. **Provider**
+## 2. **Provider Configuration**
 - **Purpose:** Configures Terraform to use your GCP project, region, and zone.
 - **How:**
   - Uses variables: `project_provider`, `region`, `zone`.
+  - Enables multi-project deployments (staging vs production).
 
 ---
 
 ## 3. **Snapshot Data Source**
 - **Resource:** `data "google_compute_snapshot" "ubyssey_snapshot"`
-- **Purpose:** Finds the latest disk snapshot matching a filter in a given project.
+- **Purpose:** Finds the latest disk snapshot matching a filter in a specified project.
 - **How:**
-  - Used to restore VM disks from backups.
+  - Uses `project_snapshot` variable to allow cross-project snapshot access.
+  - Filters snapshots using `snapshot_filter` variable.
+  - Automatically selects the most recent matching snapshot.
 
 ---
 
-## 4. **Persistent Disk**
+## 4. **Static IP Address**
+- **Resource:** `google_compute_address.vm_static_ip`
+- **Purpose:** Reserves a static external IP address for the VM.
+- **How:**
+  - Named as `{vm_name}-static-ip`.
+  - External address type for internet access.
+  - Regional scope matching the VM's region.
+
+---
+
+## 5. **Persistent Disk**
 - **Resource:** `google_compute_disk.boot_disk_from_snapshot`
-- **Purpose:** Creates a new persistent disk for the VM, either from a snapshot or an image.
+- **Purpose:** Creates a new persistent disk for the VM boot volume.
 - **How:**
-  - If `boot_disk_image` is set, uses that image.
-  - Otherwise, uses the latest snapshot found above.
+  - Conditional creation: uses snapshot OR image based on `boot_disk_image` variable.
+  - If `boot_disk_image` is null → uses latest snapshot.
+  - If `boot_disk_image` is set → uses specified image.
+  - Configurable size (`disk_size_gb`) and type (`disk_type`).
 
 ---
 
-## 5. **Compute Engine VM Instance**
+## 6. **Compute Engine VM Instance**
 - **Resource:** `google_compute_instance.ubyssey_vm`
 - **Purpose:** The main virtual machine running your application.
-- **How:**
-  - Uses the persistent disk as its boot disk.
-  - Connects to the default VPC network and subnetwork.
-  - Optionally attaches a static or ephemeral external IP.
-  - Uses a service account for permissions.
-  - Has metadata, tags, and labels for configuration and management.
+- **Key Features:**
+  - Uses the persistent disk as boot disk with auto-delete enabled.
+  - Attached to default VPC network and subnetwork.
+  - Assigned the reserved static IP address.
+  - Configured with specific service account and cloud-platform scope.
+  - Includes metadata for OS Config management.
+  - Tagged for HTTP/HTTPS firewall rules.
+  - Labeled for Google Ops Agent policy.
+  - Allows stopping for updates and automatic restart.
+  - Standard (non-preemptible) provisioning model.
 
 ---
 
-## 6. **Resource Policy for Snapshots**
+## 7. **Resource Policy for Snapshots**
 - **Resource:** `google_compute_resource_policy.snapshot_retention`
 - **Purpose:** Automates daily snapshots of the VM's boot disk and manages retention.
 - **How:**
   - Schedules daily snapshots at 03:00.
-  - Retains snapshots for a configurable number of days.
+  - Retains snapshots for a configurable number of days (`snapshot_retention_days` variable).
+  - Labels snapshots with metadata (created_by, vm_name).
+  - Keeps snapshots even if source disk is deleted.
 
 ---
 
-## 7. **Resource Policy Attachment**
+## 8. **Resource Policy Attachment**
 - **Resource:** `google_compute_disk_resource_policy_attachment.attach_policy`
 - **Purpose:** Attaches the snapshot policy to the boot disk so GCP will automatically create and manage snapshots.
+- **How:**
+  - Links the resource policy to the persistent disk.
+  - Ensures automated backup execution.
 
 ---
 
-## 8. **Network and Access**
+## 9. **Outputs**
+- **Purpose:** Provides important information about the created infrastructure.
+- **Outputs:**
+  - `vm_static_ip`: The static external IP address of the VM.
+  - `vm_internal_ip`: The internal IP address within the VPC.
+  - `vm_name`: The name of the created VM instance.
+  - `vm_zone`: The GCP zone where the VM is located.
+
+---
+
+## 10. **Network and Access**
 - **Network:**
   - The VM is attached to the default VPC network and subnetwork.
-  - `access_config {}` enables an external IP for SSH and HTTP/S access.
-- **Firewall (not shown in this script):**
-  - You may need to define firewall rules to allow SSH (port 22), HTTP (80), and HTTPS (443) access.
+  - `access_config` block assigns the static external IP for internet access.
+  - NAT IP is explicitly set to the reserved static IP address.
+- **Security:**
+  - Service account with cloud-platform scope for GCP API access.
+  - Tagged with `http-server` and `https-server` for firewall rules.
+  - OS Config enabled for patch management.
 
 ---
 
 ## **How Everything Connects**
 
-1. **Terraform** uses the GCS bucket to store state.
-2. **Provider** tells Terraform which GCP project/region/zone to use.
-3. **Snapshot data source** finds the latest backup to restore from.
-4. **Persistent disk** is created from the snapshot or image.
-5. **VM instance** is created using the persistent disk as its boot disk.
-6. **Resource policy** ensures the disk is regularly backed up.
-7. **Policy attachment** links the backup policy to the disk.
-8. **Network interface** connects the VM to the internet and internal network.
+1. **Terraform Backend** uses the GCS bucket to store and manage state.
+2. **Provider Configuration** tells Terraform which GCP project/region/zone to use.
+3. **Snapshot Data Source** finds the latest backup to restore from (supports cross-project access).
+4. **Persistent Disk** is created from the snapshot or image with specified size and type.
+5. **Static IP Address** is reserved for consistent external access.
+6. **VM Instance** is created using the persistent disk as boot disk and assigned the static IP.
+7. **Resource Policy** defines the automated snapshot schedule and retention rules.
+8. **Policy Attachment** links the backup policy to the disk for automatic execution.
+9. **Network Interface** connects the VM to the internet and internal network with the static IP.
+10. **Outputs** provide key information for external use (DNS, SSH, monitoring).
 
 ---
 
-## **Diagram**
+## **Updated Architecture Diagram**
 
 ```
 [GCS Bucket: Terraform State]
@@ -94,35 +133,48 @@ This document explains how the components defined in your Terraform script are i
 [Terraform Provider (Project/Region/Zone)]
         |
         v
-[Snapshot Data Source] ---> [Persistent Disk (from snapshot/image)]
-                                         |
-                                         v
-                        [Compute Engine VM Instance]
-                                         |
-                                         v
-                [Resource Policy] <--- [Policy Attachment]
-                                         |
-                                         v
-                                [Automatic Snapshots]
-                                         |
-                                         v
-                                [Network Interface]
+[Snapshot Data Source] -----> [Static IP Address]
+        |                           |
+        v                           v
+[Persistent Disk (from snapshot/image)] --> [Compute Engine VM Instance]
+        |                                           |
+        v                                           |
+[Resource Policy] <---> [Policy Attachment]        |
+        |                                           |
+        v                                           |
+[Automatic Daily Snapshots]                        |
+                                                    v
+                                        [Network Interface + Outputs]
 ```
 
 ---
 
-## **Summary Table**
+## **Complete Resource Summary**
 
-| Terraform Resource                                 | GCP Component                | Purpose                                    |
-|----------------------------------------------------|------------------------------|--------------------------------------------|
-| `terraform { backend "gcs" ... }`                  | GCS Bucket                   | Store Terraform state                      |
-| `provider "google" ...`                            | Project/Region/Zone          | Set GCP context                            |
-| `data "google_compute_snapshot" ...`               | Compute Snapshot             | Find latest snapshot                       |
-| `google_compute_disk.boot_disk_from_snapshot`       | Persistent Disk              | Boot disk for VM                           |
-| `google_compute_instance.ubyssey_vm`               | Compute Engine VM            | Main VM                                    |
-| `google_compute_resource_policy.snapshot_retention` | Resource Policy              | Snapshot schedule/retention                |
-| `google_compute_disk_resource_policy_attachment`    | Policy Attachment            | Attach policy to disk                      |
+| Terraform Resource                                  | GCP Component           | Purpose                                      |
+|---------------------------------------------------|-------------------------|----------------------------------------------|
+| `terraform { backend "gcs" ... }`                | GCS Bucket              | Store Terraform state                       |
+| `provider "google" ...`                           | Project/Region/Zone     | Set GCP context                             |
+| `data "google_compute_snapshot" ...`              | Compute Snapshot        | Find latest snapshot for restore             |
+| `google_compute_address.vm_static_ip`             | Static External IP      | Reserve consistent external IP address      |
+| `google_compute_disk.boot_disk_from_snapshot`     | Persistent Disk         | Boot disk for VM (from snapshot/image)      |
+| `google_compute_instance.ubyssey_vm`              | Compute Engine VM       | Main virtual machine                         |
+| `google_compute_resource_policy.snapshot_retention` | Resource Policy      | Automated snapshot schedule/retention       |
+| `google_compute_disk_resource_policy_attachment`  | Policy Attachment       | Link policy to disk for execution           |
+| `output "vm_static_ip" ...`                       | Terraform Output        | Expose static IP for external use           |
+| `output "vm_internal_ip" ...`                     | Terraform Output        | Expose internal IP for monitoring           |
+| `output "vm_name" ...`                            | Terraform Output        | Expose VM name for reference                |
+| `output "vm_zone" ...`                            | Terraform Output        | Expose zone for deployment scripts          |
 
 ---
 
-**This setup ensures your VM is created from a backup, is regularly backed up, and is managed in a reproducible, automated way using Terraform.**
+## **Key Features**
+
+- **Cross-Project Support**: Can restore from snapshots in different projects (staging from production).
+- **Flexible Boot Source**: Can boot from either snapshots or fresh images.
+- **Static IP Management**: Ensures consistent external access for DNS configuration.
+- **Automated Backups**: Daily snapshots with configurable retention.
+- **Production Ready**: Includes proper labeling, tagging, and service account configuration.
+- **Infrastructure as Code**: Fully reproducible and version-controlled infrastructure.
+
+**This setup ensures your VM infrastructure is reliable, backed up, scalable, and managed through code.**

--- a/deploy-vm/terraform-architecture.md
+++ b/deploy-vm/terraform-architecture.md
@@ -1,0 +1,128 @@
+# GCP Terraform Infrastructure Overview
+
+This document explains how the components defined in your Terraform script are interconnected and how they map to Google Cloud Platform (GCP) resources.
+
+---
+
+## 1. **Google Cloud Storage (GCS) Bucket**
+- **Purpose:** Stores the Terraform state file, which tracks all managed resources.
+- **How:**
+  - Defined in the `terraform` backend block (via `backend.conf`).
+  - Example: `ubyssey-terraform-state-bucket`.
+
+---
+
+## 2. **Provider**
+- **Purpose:** Configures Terraform to use your GCP project, region, and zone.
+- **How:**
+  - Uses variables: `project_provider`, `region`, `zone`.
+
+---
+
+## 3. **Snapshot Data Source**
+- **Resource:** `data "google_compute_snapshot" "ubyssey_snapshot"`
+- **Purpose:** Finds the latest disk snapshot matching a filter in a given project.
+- **How:**
+  - Used to restore VM disks from backups.
+
+---
+
+## 4. **Persistent Disk**
+- **Resource:** `google_compute_disk.boot_disk_from_snapshot`
+- **Purpose:** Creates a new persistent disk for the VM, either from a snapshot or an image.
+- **How:**
+  - If `boot_disk_image` is set, uses that image.
+  - Otherwise, uses the latest snapshot found above.
+
+---
+
+## 5. **Compute Engine VM Instance**
+- **Resource:** `google_compute_instance.ubyssey_vm`
+- **Purpose:** The main virtual machine running your application.
+- **How:**
+  - Uses the persistent disk as its boot disk.
+  - Connects to the default VPC network and subnetwork.
+  - Optionally attaches a static or ephemeral external IP.
+  - Uses a service account for permissions.
+  - Has metadata, tags, and labels for configuration and management.
+
+---
+
+## 6. **Resource Policy for Snapshots**
+- **Resource:** `google_compute_resource_policy.snapshot_retention`
+- **Purpose:** Automates daily snapshots of the VM's boot disk and manages retention.
+- **How:**
+  - Schedules daily snapshots at 03:00.
+  - Retains snapshots for a configurable number of days.
+
+---
+
+## 7. **Resource Policy Attachment**
+- **Resource:** `google_compute_disk_resource_policy_attachment.attach_policy`
+- **Purpose:** Attaches the snapshot policy to the boot disk so GCP will automatically create and manage snapshots.
+
+---
+
+## 8. **Network and Access**
+- **Network:**
+  - The VM is attached to the default VPC network and subnetwork.
+  - `access_config {}` enables an external IP for SSH and HTTP/S access.
+- **Firewall (not shown in this script):**
+  - You may need to define firewall rules to allow SSH (port 22), HTTP (80), and HTTPS (443) access.
+
+---
+
+## **How Everything Connects**
+
+1. **Terraform** uses the GCS bucket to store state.
+2. **Provider** tells Terraform which GCP project/region/zone to use.
+3. **Snapshot data source** finds the latest backup to restore from.
+4. **Persistent disk** is created from the snapshot or image.
+5. **VM instance** is created using the persistent disk as its boot disk.
+6. **Resource policy** ensures the disk is regularly backed up.
+7. **Policy attachment** links the backup policy to the disk.
+8. **Network interface** connects the VM to the internet and internal network.
+
+---
+
+## **Diagram**
+
+```
+[GCS Bucket: Terraform State]
+        |
+        v
+[Terraform Provider (Project/Region/Zone)]
+        |
+        v
+[Snapshot Data Source] ---> [Persistent Disk (from snapshot/image)]
+                                         |
+                                         v
+                        [Compute Engine VM Instance]
+                                         |
+                                         v
+                [Resource Policy] <--- [Policy Attachment]
+                                         |
+                                         v
+                                [Automatic Snapshots]
+                                         |
+                                         v
+                                [Network Interface]
+```
+
+---
+
+## **Summary Table**
+
+| Terraform Resource                                 | GCP Component                | Purpose                                    |
+|----------------------------------------------------|------------------------------|--------------------------------------------|
+| `terraform { backend "gcs" ... }`                  | GCS Bucket                   | Store Terraform state                      |
+| `provider "google" ...`                            | Project/Region/Zone          | Set GCP context                            |
+| `data "google_compute_snapshot" ...`               | Compute Snapshot             | Find latest snapshot                       |
+| `google_compute_disk.boot_disk_from_snapshot`       | Persistent Disk              | Boot disk for VM                           |
+| `google_compute_instance.ubyssey_vm`               | Compute Engine VM            | Main VM                                    |
+| `google_compute_resource_policy.snapshot_retention` | Resource Policy              | Snapshot schedule/retention                |
+| `google_compute_disk_resource_policy_attachment`    | Policy Attachment            | Attach policy to disk                      |
+
+---
+
+**This setup ensures your VM is created from a backup, is regularly backed up, and is managed in a reproducible, automated way using Terraform.**

--- a/deploy-vm/variables.tf
+++ b/deploy-vm/variables.tf
@@ -1,4 +1,10 @@
-variable "project" {
+variable "project_provider" {
+  description = "GCP project ID"
+  type        = string
+  default     = "ubyssey-staging"
+}
+
+variable "project_snapshot" {
   description = "GCP project ID"
   type        = string
   default     = "ubyssey-prd"

--- a/deploy-vm/variables.tf
+++ b/deploy-vm/variables.tf
@@ -37,7 +37,7 @@ variable "machine_type" {
 variable "disk_size_gb" {
   description = "Boot disk size in GB"
   type        = number
-  default     = 40
+  default     = 50
 }
 
 variable "disk_type" {

--- a/deploy-vm/variables.tf
+++ b/deploy-vm/variables.tf
@@ -31,7 +31,7 @@ variable "vm_name" {
 variable "machine_type" {
   description = "Machine type for the VM"
   type        = string
-  default     = "e2-highcpu-8"
+  default     = "custom-4-7936"
 }
 
 variable "disk_size_gb" {

--- a/deploy-vm/variables.tf
+++ b/deploy-vm/variables.tf
@@ -1,3 +1,9 @@
+variable "gcs_bucket" {
+  description = "GCS bucket for Terraform state"
+  type        = string
+  default     = "ubyssey-terraform-state-bucket"
+}
+
 variable "project_provider" {
   description = "GCP project ID"
   type        = string

--- a/deploy-vm/variables.tf
+++ b/deploy-vm/variables.tf
@@ -55,7 +55,7 @@ variable "snapshot_filter" {
 variable "service_account_email" {
   description = "Service account email for the VM"
   type        = string
-  default     = "863738545301-compute@developer.gserviceaccount.com"
+  default     = "1012602718138-compute@developer.gserviceaccount.com"
 }
 
 variable "boot_disk_from_snapshot" {

--- a/deploy-vm/variables.tf
+++ b/deploy-vm/variables.tf
@@ -64,3 +64,8 @@ variable "boot_disk_image" {
   default     = null
 }
 
+variable "snapshot_retention_days" {
+  description = "Number of days to retain snapshots. Default is 7."
+  type        = number
+  default     = 7
+}

--- a/deploy-vm/variables.tf
+++ b/deploy-vm/variables.tf
@@ -1,9 +1,3 @@
-variable "gcs_bucket" {
-  description = "GCS bucket for Terraform state"
-  type        = string
-  default     = "ubyssey-terraform-state-bucket"
-}
-
 variable "project_provider" {
   description = "GCP project ID"
   type        = string

--- a/deploy-vm/variables.tf
+++ b/deploy-vm/variables.tf
@@ -1,0 +1,66 @@
+variable "project" {
+  description = "GCP project ID"
+  type        = string
+  default     = "ubyssey-prd"
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-west1"
+}
+
+variable "zone" {
+  description = "GCP zone"
+  type        = string
+  default     = "us-west1-a"
+}
+
+variable "vm_name" {
+  description = "Name of the VM instance"
+  type        = string
+  default     = "ubyssey-prd-vm-2"
+}
+
+variable "machine_type" {
+  description = "Machine type for the VM"
+  type        = string
+  default     = "e2-highcpu-8"
+}
+
+variable "disk_size_gb" {
+  description = "Boot disk size in GB"
+  type        = number
+  default     = 40
+}
+
+variable "disk_type" {
+  description = "Boot disk type"
+  type        = string
+  default     = "pd-balanced"
+}
+
+variable "snapshot_filter" {
+  description = "Filter for finding the latest snapshot"
+  type        = string
+  default     = "name eq ^ubyssey-prd-vm.*"
+}
+
+variable "service_account_email" {
+  description = "Service account email for the VM"
+  type        = string
+  default     = "863738545301-compute@developer.gserviceaccount.com"
+}
+
+variable "boot_disk_from_snapshot" {
+  type        = string
+  default     = "boot-disk-from-snapshot-1"
+  description = "Optional: Boot disk from snapshot, if not provided a new disk will be created with the default name"
+}
+
+variable "boot_disk_image" {
+  description = "Optional: GCP image self_link or family to use for boot disk. If set, this takes precedence over snapshot. Default is null."
+  type        = string
+  default     = null
+}
+

--- a/deploy-vm/variables.tf
+++ b/deploy-vm/variables.tf
@@ -25,7 +25,7 @@ variable "zone" {
 variable "vm_name" {
   description = "Name of the VM instance"
   type        = string
-  default     = "ubyssey-prd-vm-2"
+  default     = "ubyssey-staging-vm-2"
 }
 
 variable "machine_type" {

--- a/deploy-vm/variables.tf
+++ b/deploy-vm/variables.tf
@@ -7,7 +7,7 @@ variable "project_provider" {
 variable "project_snapshot" {
   description = "GCP project ID"
   type        = string
-  default     = "ubyssey-prd"
+  default     = "ubyssey-staging"
 }
 
 variable "region" {
@@ -49,7 +49,7 @@ variable "disk_type" {
 variable "snapshot_filter" {
   description = "Filter for finding the latest snapshot"
   type        = string
-  default     = "name eq ^ubyssey-prd-vm.*"
+  default     = "name eq ^ubyssey-staging-vm.*"
 }
 
 variable "service_account_email" {
@@ -60,7 +60,7 @@ variable "service_account_email" {
 
 variable "boot_disk_from_snapshot" {
   type        = string
-  default     = "boot-disk-from-snapshot-1"
+  default     = "ubyssey-staging-vm"
   description = "Optional: Boot disk from snapshot, if not provided a new disk will be created with the default name"
 }
 

--- a/nginx-staging.conf
+++ b/nginx-staging.conf
@@ -1,0 +1,72 @@
+worker_processes 1;
+
+events {
+  worker_connections 1024;
+  accept_mutex off;
+}
+
+http {
+  upstream app_server {
+    server django:8000 fail_timeout=0;
+  }
+
+  server {
+    # If no Host match, close the connection to prevent host spoofing
+    listen 80 default_server;
+    return 444;
+  }
+
+  # Redirect HTTP requests to HTTPS server
+  server {
+    listen 80;
+    client_max_body_size 4G;
+
+    server_name staging.ubyssey.ca;
+
+    keepalive_timeout 5;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot/;
+    }
+    location / {
+        return 301 https://staging.ubyssey.ca$request_uri;
+    }
+  }
+
+  # Redirect HTTPS requests for www.staging.ubyssey.ca to staging.ubyssey.ca
+  server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    client_max_body_size 4G;
+
+    server_name www.staging.ubyssey.ca;
+
+    ssl_certificate /etc/letsencrypt/live/www.staging.ubyssey.ca/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/www.staging.ubyssey.ca/privkey.pem;
+
+    location / {
+        return 301 https://staging.ubyssey.ca$request_uri;
+    }
+  }
+
+  # Handle staging.ubyssey.ca HTTPS traffic
+  server {
+    listen 443 default_server ssl;
+    listen [::]:443 ssl;
+    client_max_body_size 4G;
+
+    server_name staging.ubyssey.ca;
+
+    ssl_certificate /etc/letsencrypt/live/staging.ubyssey.ca/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/staging.ubyssey.ca/privkey.pem;
+
+    # Proxy all traffic to the Django app server
+    location / {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header Host $http_host;
+      proxy_redirect off;
+      proxy_pass http://app_server;
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a comprehensive Terraform-based workflow for managing Google Cloud Platform (GCP) virtual machine (VM) deployments in both production and staging environments. It includes new GitHub Actions workflows, Terraform configurations, and a deployment script to streamline the deployment and destruction of resources. Below are the key changes grouped by theme:

### GitHub Actions Workflows
* Added `.github/workflows/deploy_vm_production.yml` to define a workflow for deploying or destroying production VMs using Terraform. It includes steps for authentication, initialization, planning, applying, and destroying resources.
* Added `.github/workflows/deploy_vm_staging.yml` for staging VMs with a similar structure to the production workflow but configured for the staging environment.

### Terraform Configuration
* Created `deploy-vm/main.tf` to define the Terraform configuration for managing GCP resources, including VM instances, disks, and snapshot policies.
* Added `deploy-vm/variables.tf` to define reusable variables for the Terraform configuration, such as project IDs, VM names, and resource parameters.
* Added backend configuration files (`deploy-vm/backend-production.conf` and `deploy-vm/backend-staging.conf`) to specify GCS buckets for storing Terraform state. [[1]](diffhunk://#diff-58a88e19704beddf908e504699f7d1c716c7cbc2b102fadc174dc0a3d30938d2R1-R2) [[2]](diffhunk://#diff-1e694389f408773242dacbebd204f00c6ff546a233352a640de1660775e3a8b1R1-R2)

### Deployment Script
* Introduced `deploy-vm/deploy.sh`, a Bash script to automate Terraform installation, GCP authentication, and resource deployment or destruction. It includes robust error handling and logging.