### PR TITLE
modified logs to be of json format for GCP

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -71,12 +71,13 @@ LOGGING = {
    'formatters': {
        'json': {
            '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
-           'format': '%(asctime)s %(name)s %(levelname)s %(message)s',
+           'fmt': '%(asctime)s %(name)s %(levelname)s %(message)s',
+           'reserved_attrs': ['name', 'msg', 'args', 'levelname', 'levelno', 'pathname', 'filename', 'module', 'lineno', 'funcName', 'created', 'msecs', 'relativeCreated', 'thread', 'threadName', 'processName', 'process', 'stack_info'],
        },
    },
    'handlers': {
        'console': {
-           'level': 'DEBUG',
+           'level': 'INFO', 
            'class': 'logging.StreamHandler',
            'stream': sys.stdout,
            'formatter': 'json'
@@ -85,7 +86,7 @@ LOGGING = {
    'loggers': {
        '': {
            'handlers': ['console'],
-           'level': 'DEBUG',
+           'level': 'INFO',  
            'propagate': True,
        },
    },

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -69,8 +69,9 @@ LOGGING = {
    'version': 1,
    'disable_existing_loggers': False,
    'formatters': {
-       'verbose': {
-           'format': '%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+       'json': {
+           '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
+           'format': '%(asctime)s %(name)s %(levelname)s %(message)s',
        },
    },
    'handlers': {
@@ -78,7 +79,7 @@ LOGGING = {
            'level': 'DEBUG',
            'class': 'logging.StreamHandler',
            'stream': sys.stdout,
-           'formatter': 'verbose'
+           'formatter': 'json'
        },
    },
    'loggers': {

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -71,7 +71,7 @@ LOGGING = {
    'formatters': {
        'json': {
            '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
-           'fmt': '%(asctime)s %(name)s %(levelname)s %(message)s',
+           'format': '%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
            'reserved_attrs': ['name', 'msg', 'args', 'levelname', 'levelno', 'pathname', 'filename', 'module', 'lineno', 'funcName', 'created', 'msecs', 'relativeCreated', 'thread', 'threadName', 'processName', 'process', 'stack_info'],
        },
    },

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ appengine-python-standard>=1.0.0
 icalendar===5.0.12
 selenium===4.23.1
 aiohttp===3.10.3
+python-json-logger==2.0.7


### PR DESCRIPTION

This pull request updates the logging configuration in the `config/settings/production.py` file to switch from a verbose text-based formatter to a JSON-based formatter for improved log parsing and integration with structured logging tools.

Logging configuration changes:

* Replaced the `verbose` formatter with a `json` formatter that uses `pythonjsonlogger.JsonFormatter` for structured JSON logging.
* Updated the `console` handler to use the new `json` formatter instead of the `verbose` formatter.