### PR TITLE
Add intra article image banner block as option for article content stream

### DIFF
--- a/article/blocks_inner_article.py
+++ b/article/blocks_inner_article.py
@@ -460,6 +460,7 @@ class ImageWallTwoTracks(blocks.StructBlock):
             ('sizing-large-right', "Large right"),
         ],
         required=True,
+        help_text="The large size will take up 2/3 of the width",
     )
     height = blocks.ChoiceBlock(
         choices = [
@@ -523,6 +524,14 @@ class ImageWall(blocks.StructBlock):
 
     class Meta:
         template = "article/stream_blocks/image-wall-container.html"
+
+class IntraArticleImageBanner(blocks.StructBlock):
+    image = image_blocks.ReducedImageBlock()
+    header = blocks.CharBlock()
+    text = blocks.CharBlock()
+
+    class Meta:
+        template = 'article/stream_blocks/image-banner.html'
 
 # Card block
 

--- a/article/models.py
+++ b/article/models.py
@@ -1381,6 +1381,7 @@ class StandardArticlePage(ArticlePage):
                 template = 'article/stream_blocks/gallery.html',
             )),
             ('cards', blocks_inner_article.CardContainer()),
+            ('image_header', blocks_inner_article.IntraArticleImageBanner()),
         ],
         null=True,
         blank=True,

--- a/article/templates/article/stream_blocks/image-banner.html
+++ b/article/templates/article/stream_blocks/image-banner.html
@@ -1,0 +1,13 @@
+{% load wagtailimages_tags %}
+
+{% image self.image.image original as banner_image %}
+
+<div class="o-image-banner" style="--image_url: url('{{banner_image.full_url}}')" aria-label="{{self.image.alt_text}}">
+    <div class="o-image-banner--shadow">
+        <div class="o-image-banner--shadow-content">
+            <span class="o-image-banner--shadow-content--header">{{self.header|safe}}</span>
+            {{self.text|safe}}
+        </div>
+        <div class="o-image-banner--shadow--credit">{{self.image.credit|safe}}</div>
+    </div>
+</div>

--- a/ubyssey/static_src/src/styles/modules/article/_embeds.scss
+++ b/ubyssey/static_src/src/styles/modules/article/_embeds.scss
@@ -865,3 +865,47 @@ div.article-content>p.drop-cap {
 div.article-content>p.drop-cap:first-child {
   margin-top: 1em;
 }
+
+// Image banner
+.o-image-banner {
+  margin-block: 1.4em;
+
+  position: relative;
+  width: 100%;
+  height: 100vh;
+
+  background-image: var(--image_url);
+  background-size: cover;
+  background-attachment: fixed;
+  background-position: top;
+
+  .o-image-banner--shadow {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 8em 2em 2em 2em;
+    
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+
+    background-image: linear-gradient(-180deg, rgba(0, 0, 0, 0) 1%, rgba(0, 0, 0, 0.84) 99%);
+    
+    color: #aaa;
+    font-family: fonts.$font-body;
+    .o-image-banner--shadow-content {
+      margin-right: auto;
+      width: 100%;
+      max-width: 600px;
+      .o-image-banner--shadow-content--header {
+        margin-right: 1em;
+        color: #d9d9d9;
+        font-variation-settings: "wght" 600;
+        font-family: fonts.$font-headline;
+      }
+    }
+    .o-image-banner--shadow--credit {
+      font-style: italic;
+    }
+  }
+}


### PR DESCRIPTION
the banner is full width and has the background image set to attachment fixed. There is a header and caption in front of a shadow at the bottom.

This will be used for breaking up articles with multiple sections and available photos for representing those sections

<img width="2880" height="1618" alt="image" src="https://github.com/user-attachments/assets/acbd3fb1-5130-484d-9a44-3fba283cedc1" />
