### PR TITLE
Copy "client pooling" options for caching from django docs

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -24,6 +24,12 @@ CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'LOCATION': 'cache:11211',
+        "OPTIONS": {
+            "no_delay": True,
+            "ignore_exc": True,
+            "max_pool_size": 4,
+            "use_pooling": True,
+        },
     }
 }
 


### PR DESCRIPTION
Copy cache settings from django docs described as "Here’s an example configuration for a pymemcache based backend that enables client pooling (which may improve performance by keeping clients connected), treats memcache/network errors as cache misses, and sets the TCP_NODELAY flag on the connection’s socket:"