### PR TITLE
Database and caching connection pooling

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -204,7 +204,7 @@ SQL_PASSWORD = env('SQL_PASSWORD') or read_file(env('SQL_PASSWORD_FILE')) or 'ub
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.mysql',
+        'ENGINE': 'dj_db_conn_pool.backends.mysql',
         'HOST': env('SQL_HOST'),
         'NAME': env('SQL_DATABASE'),
         'USER': env('SQL_USER'),
@@ -214,6 +214,11 @@ DATABASES = {
             "charset": "utf8mb4",
             "collation": "utf8mb4_0900_ai_ci",
         },
+        'POOL_OPTIONS': {
+            'POOL_SIZE': 10,
+            'MAX_OVERFLOW': 10,
+            'RECYCLE': 24 * 60 * 60
+        }
     },
 }
 

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -24,6 +24,12 @@ CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
         'LOCATION': 'cache:11211',
+        "OPTIONS": {
+            "no_delay": True,
+            "ignore_exc": True,
+            "max_pool_size": 4,
+            "use_pooling": True,
+        },
     }
 }
 

--- a/requirements-prd.txt
+++ b/requirements-prd.txt
@@ -46,3 +46,8 @@ selenium===4.23.1
 aiohttp===3.10.3
 python-json-logger==2.0.7
 django-health-check>=3.17.0
+
+SQLAlchemy==2.0.46
+django-db-connection-pool==1.2.6
+greenlet==3.3.1
+sqlparams==6.2.0

--- a/requirements-prd.txt
+++ b/requirements-prd.txt
@@ -47,7 +47,4 @@ aiohttp===3.10.3
 python-json-logger==2.0.7
 django-health-check>=3.17.0
 
-SQLAlchemy==2.0.46
 django-db-connection-pool==1.2.6
-greenlet==3.3.1
-sqlparams==6.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,8 @@ selenium===4.23.1
 aiohttp===3.10.3
 python-json-logger==2.0.7
 django-health-check>=3.17.0
+
+SQLAlchemy==2.0.46
+django-db-connection-pool==1.2.6
+greenlet==3.3.1
+sqlparams==6.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,4 @@ aiohttp===3.10.3
 python-json-logger==2.0.7
 django-health-check>=3.17.0
 
-SQLAlchemy==2.0.46
 django-db-connection-pool==1.2.6
-greenlet==3.3.1
-sqlparams==6.2.0

--- a/ubyssey/templates/500.html
+++ b/ubyssey/templates/500.html
@@ -29,9 +29,11 @@
             <p>We are facing an internal server problem. Kindly come back again later</p>
             <p>Questions? Contact EMAIL: <a class="email-link"
                     href="mailto:webmaster@ubyssey.ca">webmaster@ubyssey.ca</a></p>
+            {% comment %}
             {% if request.path|get_id %}
             <a class="admin-edit-link" href="/admin/pages/{{ request.path|get_id }}/edit">Edit this page in admin</a>
             {% endif %}
+            {% endcomment %}
         </div>
     </div>
 </main>


### PR DESCRIPTION
When a server is asynchronous it makes more concurrent requests. Because we recently switched to an asynchronous server, the mysql database and memecache cache services were being hit by too many connections and failing (at least this is my understanding). I've turned on connection pooling settings which allows sharing of connections to these services between threads. This reduces the number of concurrent requests. I've done load testing with our staging server and this removed the errors related to mysql and memcache