### PR TITLE
Native Data Visualizations in CMS

### DIFF
--- a/article/blocks_inner_article.py
+++ b/article/blocks_inner_article.py
@@ -648,3 +648,25 @@ class VisualEssayBlock(blocks.StructBlock):
     class Meta:
         template = 'article/stream_blocks/visual-essay.html',
         icon = "form"
+
+class D3ChartBlock(blocks.StructBlock):
+    chart_title = blocks.CharBlock(required=False)
+    
+    chart_type = blocks.ChoiceBlock(
+        choices=[
+            ('scatter-plot', 'Scatter Plot'),
+            ('pie-chart', 'Pie Chart'),
+            ('histogram', 'Histogram'),
+        ],
+        default='scatter-plot',
+        required=True,
+    )
+
+    data = blocks.TextBlock(
+        required=True,
+        help_text="Enter your data here (csv format)",
+        rows=10
+    )
+
+    class Meta:
+        template = 'article/stream_blocks/d3-chart.html'

--- a/article/models.py
+++ b/article/models.py
@@ -1379,6 +1379,7 @@ class StandardArticlePage(ArticlePage):
             ('header_menu', blocks_inner_article.HeaderMenuBlock()),
             ('visual_essay', blocks_inner_article.VisualEssayBlock()),
             ('personality_quiz', blocks_inner_article.PersonalityQuizBlock()),
+            ('D3_chart', blocks_inner_article.D3ChartBlock()),
             ('plaintext', blocks.TextBlock(
                 label="Plain Text Block",
                 help_text = "Warning: Rich Text Blocks preferred! Plain text primarily exists for importing old Dispatch text."

--- a/article/templates/article/stream_blocks/d3-chart.html
+++ b/article/templates/article/stream_blocks/d3-chart.html
@@ -1,0 +1,17 @@
+{% load wagtailcore_tags %}
+{% load wagtailimages_tags %}
+
+{% with chart_id="d3-chart-"|add:block.id %}
+<div class="d3-wrapper">
+    {% if self.chart_title %}<h3>{{ self.chart_title }}</h3>{% endif %}
+
+    <div id="{{ chart_id }}" 
+         class="d3-chart-container" 
+         data-type="{{ self.chart_type }}">
+    </div>
+
+    <script id="data-{{ chart_id }}" type="text/plain">
+        {{ self.data|safe }}
+    </script>
+</div>
+{% endwith %}

--- a/ubyssey/static_src/package.json
+++ b/ubyssey/static_src/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "@svgr/webpack": "^8.1.0",
     "axios": "^1.7.4",
+    "d3": "^7.9.0",
     "global": "^4.3.2",
     "gsap": "^3.13.0",
     "js-cookie": "^2.2.0",

--- a/ubyssey/static_src/src/js/article_content.js
+++ b/ubyssey/static_src/src/js/article_content.js
@@ -1,6 +1,15 @@
 import { gsap } from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 
+// D3 Stuff - Is it more efficient to do it this way?
+import { select } from "d3-selection";
+import { scaleLinear, scaleTime, scaleOrdinal } from "d3-scale";
+import { extent, max, bin } from "d3-array";
+import { axisBottom, axisLeft } from "d3-axis";
+import { timeParse } from "d3-time-format";
+import { pie, arc } from "d3-shape";
+import { csvParse } from "d3-dsv";
+
 gsap.registerPlugin(ScrollTrigger);
 
 let mm = gsap.matchMedia();
@@ -23,3 +32,147 @@ mm.add("(min-width: 1px), (min-height: 1px)", () => {
         });
     })
 })
+
+// D3 Rendering
+
+// Handle Dates
+function parseData(data) {
+    const parseTime = timeParse("%Y-%m-%d");
+    return data.map(d => {
+        const processed = {};
+        for (let key in d) {
+            const val = d[key].trim();
+            const dateVal = parseTime(val);
+            if (dateVal) {
+                processed[key] = dateVal;
+            } else if (!isNaN(val) && val !== "") {
+                processed[key] = +val;
+            } else {
+                processed[key] = val;
+            }
+        }
+        return processed;
+    });
+}
+
+// Draw Charts
+const CHART_CONFIG = {
+    width: 400,
+    height: 300,
+    margin: { top: 20, right: 0, bottom: 50, left: 0 },
+    pieMargin: 10
+};
+
+function createBaseSvg(id, isSquare = false) {
+    const { width, height, margin } = CHART_CONFIG;
+    const activeHeight = isSquare ? width : height;
+
+    const svg = select(`#${id}`)
+        .append("svg")
+        .attr("viewBox", `0 0 ${width} ${activeHeight}`)
+        .attr("preserveAspectRatio", "xMinYMin meet");
+
+    const g = svg.append("g")
+        .attr("transform", `translate(${margin.left},${margin.top})`);
+
+    return {
+        g,
+        innerWidth: width - margin.left - margin.right,
+        innerHeight: activeHeight - margin.top - margin.bottom
+    };
+}
+
+function renderScatter(id, data) {
+    if (!data || !data.length) return;
+    const { g, innerWidth, innerHeight } = createBaseSvg(id);
+
+    const keys = Object.keys(data[0]);
+    const xKey = keys[0], yKey = keys[1];
+
+    const xScale = (data[0][xKey] instanceof Date) 
+        ? scaleTime().domain(extent(data, d => d[xKey])).range([0, innerWidth])
+        : scaleLinear().domain(extent(data, d => d[xKey])).range([0, innerWidth]);
+
+    const yScale = scaleLinear()
+        .domain([0, max(data, d => d[yKey])]).range([innerHeight, 0]);
+
+    g.append("g").attr("transform", `translate(0,${innerHeight})`).call(axisBottom(xScale));
+    g.append("g").call(axisLeft(yScale));
+
+    g.selectAll("circle").data(data).enter().append("circle")
+        .attr("cx", d => xScale(d[xKey]))
+        .attr("cy", d => yScale(d[yKey]))
+        .attr("r", 5)
+        .style("fill", "#006DCC")
+        .style("opacity", 0.7);
+}
+
+function renderPie(id, data) {
+    if (!data || !data.length) return;
+    const { width } = CHART_CONFIG;
+    const radius = (width / 2) - CHART_CONFIG.pieMargin;
+
+    const svg = select(`#${id}`).append("svg")
+        .attr("viewBox", `0 0 ${width} ${width}`)
+        .append("g")
+        .attr("transform", `translate(${width / 2},${width / 2})`);
+
+    const keys = Object.keys(data[0]);
+    
+    // From SCSS files
+    const ubysseyPalette = ["#0071c9", "#006DCC", "#BBE3F1", "#01283D", "#0073A9"];
+    const color = scaleOrdinal(ubysseyPalette);
+
+    const newpie = pie().value(d => d[keys[1]]).sort(null);
+    const newarc = arc().innerRadius(0).outerRadius(radius);
+
+    svg.selectAll('path')
+        .data(newpie(data))
+        .join('path')
+        .attr('d', newarc)
+        .attr('fill', (d, i) => color(i));
+}
+
+function renderHistogram(id, data) {
+    if (!data || !data.length) return;
+    const { g, innerWidth, innerHeight } = createBaseSvg(id);
+
+    const key = Object.keys(data[0])[0];
+    const x = scaleLinear().domain(extent(data, d => d[key])).range([0, innerWidth]);
+
+    const bins = bin().value(d => d[key]).domain(x.domain()).thresholds(x.ticks(10))(data);
+
+    const y = scaleLinear()
+        .domain([0, max(bins, d => d.length)]).range([innerHeight, 0]);
+
+    g.append("g").attr("transform", `translate(0,${innerHeight})`).call(axisBottom(x));
+    g.append("g").call(axisLeft(y));
+
+    g.selectAll("rect").data(bins).enter().append("rect")
+        .attr("transform", d => `translate(${x(d.x0)},${y(d.length)})`)
+        .attr("width", d => Math.max(0, x(d.x1) - x(d.x0) - 1))
+        .attr("height", d => innerHeight - y(d.length))
+}
+
+const charts = document.querySelectorAll('.d3-chart-container');
+
+charts.forEach(container => {
+    const id = container.id;
+    const type = container.dataset.type;
+    const rawDataElement = document.getElementById(`data-${id}`);
+    
+    if (!rawDataElement) return;
+
+    const rawData = rawDataElement.textContent.trim();
+    const csvData = csvParse(rawData);
+    // Checks for Dates/Strings
+    const cleanData = parseData(csvData);
+
+    if (type === 'pie-chart') {
+        renderPie(id, cleanData);
+    } else if (type === 'scatter-plot') {
+        renderScatter(id, cleanData);
+    } else if (type === 'histogram') {
+        renderHistogram(id, cleanData);
+    }
+});

--- a/ubyssey/static_src/src/styles/article.scss
+++ b/ubyssey/static_src/src/styles/article.scss
@@ -24,6 +24,7 @@
 @use 'modules/article/special_page.scss';
 @use 'modules/article/visual_essay';
 @use 'modules/article/personality_quiz';
+@use 'modules/article/d3_charts';
 
 @use 'components/carousel';
 

--- a/ubyssey/static_src/src/styles/modules/article/_d3_charts.scss
+++ b/ubyssey/static_src/src/styles/modules/article/_d3_charts.scss
@@ -1,0 +1,78 @@
+@use '../variables';
+@use '../fonts';
+
+.d3-wrapper {
+    // Does not work - currently controlling via chart-container width
+    //max-width: 500px;
+    //margin: 2rem auto;
+    
+    h3 {
+        font-family: fonts.$font-headline;
+        color: var(--header_color-100);
+        text-align: center;
+        margin-bottom: 1rem;
+    }
+}
+
+.d3-chart-container {
+    margin: auto;
+    width: 40%;
+    font-family: fonts.$font-default;
+
+    @media(variables.$bp-smaller-than-phablet) {
+        max-width: 100%;
+        padding: 0 variables.$article-content-div-child-padding;
+    }
+
+    svg {
+        display: block;
+        width: 100%;
+        height: auto;
+        overflow: visible;
+
+        text {
+            fill: var(--text_color-200);
+            font-size: fonts.$font-size-14px;
+            font-weight: fonts.$font-weight-normal;
+            letter-spacing: fonts.$letter-spacing-noto-sans;
+        }
+
+        .domain,
+        .tick line {
+            stroke: var(--border-grey);
+            stroke-width: 1px;
+        }
+
+        // Scatter Plot Circles
+        circle {
+            fill: variables.$color-ubyssey-blue;
+            transition: r 0.2s ease, opacity 0.2s ease;
+            &:hover {
+                r: 7; // Radius
+                cursor: pointer;
+                fill: variables.$color-ubyssey-blue-classic;
+            }
+        }
+
+        // Histogram Bars
+        rect {
+            fill: variables.$color-ubyssey-blue-light;
+            &:hover {
+                cursor: pointer;
+                fill: variables.$color-ubyssey-blue;
+            }
+        }
+
+        // Pie Chart Paths
+        path {
+            stroke: var(--background); // Maybe should change back to old theme
+            stroke-width: 2px;
+            transition: transform 0.2s ease;
+
+            &:hover {
+                opacity: 0.9;
+                cursor: pointer;
+            }
+        }
+    }
+}


### PR DESCRIPTION
[Issue: Add native data visualizations in CMS #1696 ](https://github.com/ubyssey/ubyssey.ca/issues/1696#issue-3811367193)

I have chart basics implemented, so it should be easy to add more chart types, and style the existing ones.

Currently implemented chart types: Scatter Plot, Pie Chart, and Histogram.

CSS chart scaling is a little funky right now so need to work on that before merging with main.